### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,21 +14,21 @@
       "devDependencies": {
         "@types/chai": "4.3.5",
         "@types/mocha": "10.0.1",
-        "@types/node": "20.4.5",
-        "@typescript-eslint/eslint-plugin": "6.2.1",
-        "@typescript-eslint/parser": "6.2.1",
+        "@types/node": "20.4.8",
+        "@typescript-eslint/eslint-plugin": "6.3.0",
+        "@typescript-eslint/parser": "6.3.0",
         "chai": "4.3.7",
         "clean-webpack-plugin": "4.0.0",
         "emojilib": "3.0.10",
         "eslint": "8.46.0",
-        "eslint-config-prettier": "8.9.0",
+        "eslint-config-prettier": "9.0.0",
         "eslint-plugin-import": "2.28.0",
         "eslint-plugin-prettier": "5.0.0",
         "eslint-webpack-plugin": "4.0.1",
         "mocha": "10.2.0",
         "nodemon": "3.0.1",
-        "npm-check-updates": "16.10.17",
-        "prettier": "3.0.0",
+        "npm-check-updates": "16.10.18",
+        "prettier": "3.0.1",
         "ts-loader": "9.4.4",
         "ts-node": "10.9.1",
         "typescript": "5.1.6",
@@ -821,9 +821,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
+      "version": "20.4.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.8.tgz",
+      "integrity": "sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -848,16 +848,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.2.1.tgz",
-      "integrity": "sha512-iZVM/ALid9kO0+I81pnp1xmYiFyqibAHzrqX4q5YvvVEyJqY+e6rfTXSCsc2jUxGNqJqTfFSSij/NFkZBiBzLw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.3.0.tgz",
+      "integrity": "sha512-IZYjYZ0ifGSLZbwMqIip/nOamFiWJ9AH+T/GYNZBWkVcyNQOFGtSMoWV7RvY4poYCMZ/4lHzNl796WOSNxmk8A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.2.1",
-        "@typescript-eslint/type-utils": "6.2.1",
-        "@typescript-eslint/utils": "6.2.1",
-        "@typescript-eslint/visitor-keys": "6.2.1",
+        "@typescript-eslint/scope-manager": "6.3.0",
+        "@typescript-eslint/type-utils": "6.3.0",
+        "@typescript-eslint/utils": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -884,15 +884,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.2.1.tgz",
-      "integrity": "sha512-Ld+uL1kYFU8e6btqBFpsHkwQ35rw30IWpdQxgOqOh4NfxSDH6uCkah1ks8R/RgQqI5hHPXMaLy9fbFseIe+dIg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.3.0.tgz",
+      "integrity": "sha512-ibP+y2Gr6p0qsUkhs7InMdXrwldjxZw66wpcQq9/PzAroM45wdwyu81T+7RibNCh8oc0AgrsyCwJByncY0Ongg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.2.1",
-        "@typescript-eslint/types": "6.2.1",
-        "@typescript-eslint/typescript-estree": "6.2.1",
-        "@typescript-eslint/visitor-keys": "6.2.1",
+        "@typescript-eslint/scope-manager": "6.3.0",
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/typescript-estree": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -912,13 +912,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.2.1.tgz",
-      "integrity": "sha512-UCqBF9WFqv64xNsIEPfBtenbfodPXsJ3nPAr55mGPkQIkiQvgoWNo+astj9ZUfJfVKiYgAZDMnM6dIpsxUMp3Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.3.0.tgz",
+      "integrity": "sha512-WlNFgBEuGu74ahrXzgefiz/QlVb+qg8KDTpknKwR7hMH+lQygWyx0CQFoUmMn1zDkQjTBBIn75IxtWss77iBIQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.2.1",
-        "@typescript-eslint/visitor-keys": "6.2.1"
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -929,13 +929,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.2.1.tgz",
-      "integrity": "sha512-fTfCgomBMIgu2Dh2Or3gMYgoNAnQm3RLtRp+jP7A8fY+LJ2+9PNpi5p6QB5C4RSP+U3cjI0vDlI3mspAkpPVbQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.3.0.tgz",
+      "integrity": "sha512-7Oj+1ox1T2Yc8PKpBvOKWhoI/4rWFd1j7FA/rPE0lbBPXTKjdbtC+7Ev0SeBjEKkIhKWVeZSP+mR7y1Db1CdfQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.2.1",
-        "@typescript-eslint/utils": "6.2.1",
+        "@typescript-eslint/typescript-estree": "6.3.0",
+        "@typescript-eslint/utils": "6.3.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -956,9 +956,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.2.1.tgz",
-      "integrity": "sha512-528bGcoelrpw+sETlyM91k51Arl2ajbNT9L4JwoXE2dvRe1yd8Q64E4OL7vHYw31mlnVsf+BeeLyAZUEQtqahQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.3.0.tgz",
+      "integrity": "sha512-K6TZOvfVyc7MO9j60MkRNWyFSf86IbOatTKGrpTQnzarDZPYPVy0oe3myTMq7VjhfsUAbNUW8I5s+2lZvtx1gg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -969,13 +969,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.2.1.tgz",
-      "integrity": "sha512-G+UJeQx9AKBHRQBpmvr8T/3K5bJa485eu+4tQBxFq0KoT22+jJyzo1B50JDT9QdC1DEmWQfdKsa8ybiNWYsi0Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.3.0.tgz",
+      "integrity": "sha512-Xh4NVDaC4eYKY4O3QGPuQNp5NxBAlEvNQYOqJquR2MePNxO11E5K3t5x4M4Mx53IZvtpW+mBxIT0s274fLUocg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.2.1",
-        "@typescript-eslint/visitor-keys": "6.2.1",
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/visitor-keys": "6.3.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -996,17 +996,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.2.1.tgz",
-      "integrity": "sha512-eBIXQeupYmxVB6S7x+B9SdBeB6qIdXKjgQBge2J+Ouv8h9Cxm5dHf/gfAZA6dkMaag+03HdbVInuXMmqFB/lKQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.3.0.tgz",
+      "integrity": "sha512-hLLg3BZE07XHnpzglNBG8P/IXq/ZVXraEbgY7FM0Cnc1ehM8RMdn9mat3LubJ3KBeYXXPxV1nugWbQPjGeJk6Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.2.1",
-        "@typescript-eslint/types": "6.2.1",
-        "@typescript-eslint/typescript-estree": "6.2.1",
+        "@typescript-eslint/scope-manager": "6.3.0",
+        "@typescript-eslint/types": "6.3.0",
+        "@typescript-eslint/typescript-estree": "6.3.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1021,12 +1021,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.2.1.tgz",
-      "integrity": "sha512-iTN6w3k2JEZ7cyVdZJTVJx2Lv7t6zFA8DCrJEHD2mwfc16AEvvBWVhbFh34XyG2NORCd0viIgQY1+u7kPI0WpA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.3.0.tgz",
+      "integrity": "sha512-kEhRRj7HnvaSjux1J9+7dBen15CdWmDnwrpyiHsFX6Qx2iW5LOBUgNefOFeh2PjWPlNwN8TOn6+4eBU3J/gupw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.2.1",
+        "@typescript-eslint/types": "6.3.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2884,9 +2884,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
-      "integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -5567,9 +5567,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.10.17",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.10.17.tgz",
-      "integrity": "sha512-ZoIbWYJhlgMDoByq1WC6Ys3E76IvNCxgS54tPUFbK5J/nqf/BCJt6xiMPAEa7G1HuyAruG+orUF9uTsTGUZl8g==",
+      "version": "16.10.18",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.10.18.tgz",
+      "integrity": "sha512-dmfhCMX7+UNrBeftBGb1rMX4Qi6+FOI5cuu1VkLeE4LIazbiEYsdgTG+GQywYry+BR9R3EfOXITYPfgRhcdznw==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
@@ -6370,9 +6370,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -57,16 +57,16 @@
   "devDependencies": {
     "@types/chai": "4.3.5",
     "@types/mocha": "10.0.1",
-    "@types/node": "20.4.5",
-    "@typescript-eslint/eslint-plugin": "6.2.1",
-    "@typescript-eslint/parser": "6.2.1",
+    "@types/node": "20.4.8",
+    "@typescript-eslint/eslint-plugin": "6.3.0",
+    "@typescript-eslint/parser": "6.3.0",
     "chai": "4.3.7",
     "clean-webpack-plugin": "4.0.0",
     "emojilib": "3.0.10",
     "eslint": "8.46.0",
     "eslint-plugin-import": "2.28.0",
     "eslint-plugin-prettier": "5.0.0",
-    "eslint-config-prettier": "8.9.0",
+    "eslint-config-prettier": "9.0.0",
     "eslint-webpack-plugin": "4.0.1",
     "mocha": "10.2.0",
     "nodemon": "3.0.1",
@@ -76,7 +76,7 @@
     "unicode-emoji-json": "0.4.0",
     "webpack": "5.88.2",
     "webpack-cli": "5.1.4",
-    "prettier": "3.0.0",
-    "npm-check-updates": "16.10.17"
+    "prettier": "3.0.1",
+    "npm-check-updates": "16.10.18"
   }
 }


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node                         20.4.5  →    20.4.8
⬆️ @typescript-eslint/eslint-plugin     6.2.1  →     6.3.0
⬆️ @typescript-eslint/parser            6.2.1  →     6.3.0
⬆️ eslint-config-prettier               8.9.0  →     9.0.0
⬆️ npm-check-updates                 16.10.17  →  16.10.18
⬆️ prettier                             3.0.0  →     3.0.1