### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,20 +14,20 @@
       "devDependencies": {
         "@types/chai": "4.3.6",
         "@types/mocha": "10.0.1",
-        "@types/node": "20.5.9",
-        "@typescript-eslint/eslint-plugin": "6.6.0",
-        "@typescript-eslint/parser": "6.6.0",
+        "@types/node": "20.6.0",
+        "@typescript-eslint/eslint-plugin": "6.7.0",
+        "@typescript-eslint/parser": "6.7.0",
         "chai": "4.3.8",
         "clean-webpack-plugin": "4.0.0",
         "emojilib": "3.0.10",
-        "eslint": "8.48.0",
+        "eslint": "8.49.0",
         "eslint-config-prettier": "9.0.0",
         "eslint-plugin-import": "2.28.1",
         "eslint-plugin-prettier": "5.0.0",
         "eslint-webpack-plugin": "4.0.1",
         "mocha": "10.2.0",
         "nodemon": "3.0.1",
-        "npm-check-updates": "16.13.2",
+        "npm-check-updates": "16.13.3",
         "prettier": "3.0.3",
         "ts-loader": "9.4.4",
         "ts-node": "10.9.1",
@@ -125,18 +125,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
-      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+      "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -821,9 +821,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
-      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -848,16 +848,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.6.0.tgz",
-      "integrity": "sha512-CW9YDGTQnNYMIo5lMeuiIG08p4E0cXrXTbcZ2saT/ETE7dWUrNxlijsQeU04qAAKkILiLzdQz+cGFxCJjaZUmA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.0.tgz",
+      "integrity": "sha512-gUqtknHm0TDs1LhY12K2NA3Rmlmp88jK9Tx8vGZMfHeNMLE3GH2e9TRub+y+SOjuYgtOmok+wt1AyDPZqxbNag==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.6.0",
-        "@typescript-eslint/type-utils": "6.6.0",
-        "@typescript-eslint/utils": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/type-utils": "6.7.0",
+        "@typescript-eslint/utils": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -883,15 +883,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.6.0.tgz",
-      "integrity": "sha512-setq5aJgUwtzGrhW177/i+DMLqBaJbdwGj2CPIVFFLE0NCliy5ujIdLHd2D1ysmlmsjdL2GWW+hR85neEfc12w==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
+      "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.6.0",
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/typescript-estree": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -911,13 +911,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.6.0.tgz",
-      "integrity": "sha512-pT08u5W/GT4KjPUmEtc2kSYvrH8x89cVzkA0Sy2aaOUIw6YxOIjA8ilwLr/1fLjOedX1QAuBpG9XggWqIIfERw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
+      "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0"
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -928,13 +928,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.6.0.tgz",
-      "integrity": "sha512-8m16fwAcEnQc69IpeDyokNO+D5spo0w1jepWWY2Q6y5ZKNuj5EhVQXjtVAeDDqvW6Yg7dhclbsz6rTtOvcwpHg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.0.tgz",
+      "integrity": "sha512-f/QabJgDAlpSz3qduCyQT0Fw7hHpmhOzY/Rv6zO3yO+HVIdPfIWhrQoAyG+uZVtWAIS85zAyzgAFfyEr+MgBpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.6.0",
-        "@typescript-eslint/utils": "6.6.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
+        "@typescript-eslint/utils": "6.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -955,9 +955,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.6.0.tgz",
-      "integrity": "sha512-CB6QpJQ6BAHlJXdwUmiaXDBmTqIE2bzGTDLADgvqtHWuhfNP3rAOK7kAgRMAET5rDRr9Utt+qAzRBdu3AhR3sg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
+      "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -968,13 +968,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.6.0.tgz",
-      "integrity": "sha512-hMcTQ6Al8MP2E6JKBAaSxSVw5bDhdmbCEhGW/V8QXkb9oNsFkA4SBuOMYVPxD3jbtQ4R/vSODBsr76R6fP3tbA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
+      "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/visitor-keys": "6.6.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -995,17 +995,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.6.0.tgz",
-      "integrity": "sha512-mPHFoNa2bPIWWglWYdR0QfY9GN0CfvvXX1Sv6DlSTive3jlMTUy+an67//Gysc+0Me9pjitrq0LJp0nGtLgftw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
+      "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.6.0",
-        "@typescript-eslint/types": "6.6.0",
-        "@typescript-eslint/typescript-estree": "6.6.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1020,12 +1020,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.6.0.tgz",
-      "integrity": "sha512-L61uJT26cMOfFQ+lMZKoJNbAEckLe539VhTxiGHrWl5XSKQgA0RTBZJW2HFPy5T0ZvPVSD93QsrTKDkfNwJGyQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
+      "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.6.0",
+        "@typescript-eslint/types": "6.7.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2829,16 +2829,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.48.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
-      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+      "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.48.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint/js": "8.49.0",
+        "@humanwhocodes/config-array": "^0.11.11",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.12.4",
@@ -5559,9 +5559,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.13.2.tgz",
-      "integrity": "sha512-0pQI+k1y0JVwenB2gBc69tXFYfkckSVrNrlcn7TIrZfis4LnfdzakY/LYzZKt/lx37edN2isk3d2Zw4csptu/w==",
+      "version": "16.13.3",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.13.3.tgz",
+      "integrity": "sha512-l3FQtm+ZtDwqtK2r27vCuNdtnoDsXzk8D2WczvrAJy2bGPZJvRmuUa/Q9Gv+AbZV0IHSNJD2oHtQqUeqQRhEsw==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -57,13 +57,13 @@
   "devDependencies": {
     "@types/chai": "4.3.6",
     "@types/mocha": "10.0.1",
-    "@types/node": "20.5.9",
-    "@typescript-eslint/eslint-plugin": "6.6.0",
-    "@typescript-eslint/parser": "6.6.0",
+    "@types/node": "20.6.0",
+    "@typescript-eslint/eslint-plugin": "6.7.0",
+    "@typescript-eslint/parser": "6.7.0",
     "chai": "4.3.8",
     "clean-webpack-plugin": "4.0.0",
     "emojilib": "3.0.10",
-    "eslint": "8.48.0",
+    "eslint": "8.49.0",
     "eslint-plugin-import": "2.28.1",
     "eslint-plugin-prettier": "5.0.0",
     "eslint-config-prettier": "9.0.0",
@@ -77,6 +77,6 @@
     "webpack": "5.88.2",
     "webpack-cli": "5.1.4",
     "prettier": "3.0.3",
-    "npm-check-updates": "16.13.2"
+    "npm-check-updates": "16.13.3"
   }
 }


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node                        20.5.9  →   20.6.0
⬆️ @typescript-eslint/eslint-plugin    6.6.0  →    6.7.0
⬆️ @typescript-eslint/parser           6.6.0  →    6.7.0
⬆️ eslint                             8.48.0  →   8.49.0
⬆️ npm-check-updates                 16.13.2  →  16.13.3