### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "devDependencies": {
         "@types/chai": "4.3.17",
         "@types/mocha": "10.0.7",
-        "@types/node": "22.4.0",
-        "@typescript-eslint/eslint-plugin": "8.1.0",
-        "@typescript-eslint/parser": "8.1.0",
+        "@types/node": "22.4.1",
+        "@typescript-eslint/eslint-plugin": "8.2.0",
+        "@typescript-eslint/parser": "8.2.0",
         "chai": "4.4.1",
         "clean-webpack-plugin": "4.0.0",
         "emojilib": "3.0.12",
@@ -477,9 +477,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.0.tgz",
-      "integrity": "sha512-49AbMDwYUz7EXxKU/r7mXOsxwFr4BYbvB7tWYxVuLdb2ibd30ijjXINSMAHiEEZk5PCRBmW1gUeisn2VMKt3cQ==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
+      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -502,17 +502,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.1.0.tgz",
-      "integrity": "sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.2.0.tgz",
+      "integrity": "sha512-02tJIs655em7fvt9gps/+4k4OsKULYGtLBPJfOsmOq1+3cdClYiF0+d6mHu6qDnTcg88wJBkcPLpQhq7FyDz0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.1.0",
-        "@typescript-eslint/type-utils": "8.1.0",
-        "@typescript-eslint/utils": "8.1.0",
-        "@typescript-eslint/visitor-keys": "8.1.0",
+        "@typescript-eslint/scope-manager": "8.2.0",
+        "@typescript-eslint/type-utils": "8.2.0",
+        "@typescript-eslint/utils": "8.2.0",
+        "@typescript-eslint/visitor-keys": "8.2.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -536,16 +536,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.1.0.tgz",
-      "integrity": "sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.2.0.tgz",
+      "integrity": "sha512-j3Di+o0lHgPrb7FxL3fdEy6LJ/j2NE8u+AP/5cQ9SKb+JLH6V6UHDqJ+e0hXBkHP1wn1YDFjYCS9LBQsZDlDEg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.1.0",
-        "@typescript-eslint/types": "8.1.0",
-        "@typescript-eslint/typescript-estree": "8.1.0",
-        "@typescript-eslint/visitor-keys": "8.1.0",
+        "@typescript-eslint/scope-manager": "8.2.0",
+        "@typescript-eslint/types": "8.2.0",
+        "@typescript-eslint/typescript-estree": "8.2.0",
+        "@typescript-eslint/visitor-keys": "8.2.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -565,14 +565,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.1.0.tgz",
-      "integrity": "sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.2.0.tgz",
+      "integrity": "sha512-OFn80B38yD6WwpoHU2Tz/fTz7CgFqInllBoC3WP+/jLbTb4gGPTy9HBSTsbDWkMdN55XlVU0mMDYAtgvlUspGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.1.0",
-        "@typescript-eslint/visitor-keys": "8.1.0"
+        "@typescript-eslint/types": "8.2.0",
+        "@typescript-eslint/visitor-keys": "8.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -583,14 +583,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.1.0.tgz",
-      "integrity": "sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.2.0.tgz",
+      "integrity": "sha512-g1CfXGFMQdT5S+0PSO0fvGXUaiSkl73U1n9LTK5aRAFnPlJ8dLKkXr4AaLFvPedW8lVDoMgLLE3JN98ZZfsj0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.1.0",
-        "@typescript-eslint/utils": "8.1.0",
+        "@typescript-eslint/typescript-estree": "8.2.0",
+        "@typescript-eslint/utils": "8.2.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -608,9 +608,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.1.0.tgz",
-      "integrity": "sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.2.0.tgz",
+      "integrity": "sha512-6a9QSK396YqmiBKPkJtxsgZZZVjYQ6wQ/TlI0C65z7vInaETuC6HAHD98AGLC8DyIPqHytvNuS8bBVvNLKyqvQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -622,14 +622,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.1.0.tgz",
-      "integrity": "sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.2.0.tgz",
+      "integrity": "sha512-kiG4EDUT4dImplOsbh47B1QnNmXSoUqOjWDvCJw/o8LgfD0yr7k2uy54D5Wm0j4t71Ge1NkynGhpWdS0dEIAUA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.1.0",
-        "@typescript-eslint/visitor-keys": "8.1.0",
+        "@typescript-eslint/types": "8.2.0",
+        "@typescript-eslint/visitor-keys": "8.2.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -651,16 +651,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.1.0.tgz",
-      "integrity": "sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.2.0.tgz",
+      "integrity": "sha512-O46eaYKDlV3TvAVDNcoDzd5N550ckSe8G4phko++OCSC1dYIb9LTc3HDGYdWqWIAT5qDUKphO6sd9RrpIJJPfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.1.0",
-        "@typescript-eslint/types": "8.1.0",
-        "@typescript-eslint/typescript-estree": "8.1.0"
+        "@typescript-eslint/scope-manager": "8.2.0",
+        "@typescript-eslint/types": "8.2.0",
+        "@typescript-eslint/typescript-estree": "8.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -674,13 +674,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.1.0.tgz",
-      "integrity": "sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.2.0.tgz",
+      "integrity": "sha512-sbgsPMW9yLvS7IhCi8IpuK1oBmtbWUNP+hBdwl/I9nzqVsszGnNGti5r9dUtF5RLivHUFFIdRvLiTsPhzSyJ3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.1.0",
+        "@typescript-eslint/types": "8.2.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@types/chai": "4.3.17",
     "@types/mocha": "10.0.7",
-    "@types/node": "22.4.0",
-    "@typescript-eslint/eslint-plugin": "8.1.0",
-    "@typescript-eslint/parser": "8.1.0",
+    "@types/node": "22.4.1",
+    "@typescript-eslint/eslint-plugin": "8.2.0",
+    "@typescript-eslint/parser": "8.2.0",
     "chai": "4.4.1",
     "clean-webpack-plugin": "4.0.0",
     "emojilib": "3.0.12",


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node                       22.4.0  →  22.4.1
⬆️ @typescript-eslint/eslint-plugin   8.1.0  →   8.2.0
⬆️ @typescript-eslint/parser          8.1.0  →   8.2.0