### PR TITLE
🤖 Upgrading packages versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "devDependencies": {
         "@types/chai": "5.0.0",
         "@types/mocha": "10.0.9",
-        "@types/node": "22.7.5",
-        "@typescript-eslint/eslint-plugin": "8.9.0",
-        "@typescript-eslint/parser": "8.9.0",
+        "@types/node": "22.7.8",
+        "@typescript-eslint/eslint-plugin": "8.11.0",
+        "@typescript-eslint/parser": "8.11.0",
         "chai": "4.4.1",
         "clean-webpack-plugin": "4.0.0",
         "emojilib": "4.0.0",
@@ -27,7 +27,7 @@
         "eslint-webpack-plugin": "4.2.0",
         "mocha": "10.7.3",
         "nodemon": "3.1.7",
-        "npm-check-updates": "17.1.3",
+        "npm-check-updates": "17.1.4",
         "prettier": "3.3.3",
         "ts-loader": "9.5.1",
         "ts-node": "10.9.2",
@@ -475,9 +475,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.8.tgz",
+      "integrity": "sha512-a922jJy31vqR5sk+kAdIENJjHblqcZ4RmERviFsER4WJcEONqxKcjNOlk0q7OUfrF5sddT+vng070cdfMlrPLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -500,17 +500,17 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
-      "integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
+      "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.9.0",
-        "@typescript-eslint/type-utils": "8.9.0",
-        "@typescript-eslint/utils": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/type-utils": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -534,16 +534,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
-      "integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
+      "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.9.0",
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/typescript-estree": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -563,14 +563,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
-      "integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
+      "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0"
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -581,14 +581,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
-      "integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
+      "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.9.0",
-        "@typescript-eslint/utils": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
-      "integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
+      "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -620,14 +620,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
-      "integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
+      "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/visitor-keys": "8.9.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -649,16 +649,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
-      "integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
+      "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.9.0",
-        "@typescript-eslint/types": "8.9.0",
-        "@typescript-eslint/typescript-estree": "8.9.0"
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -672,13 +672,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
-      "integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
+      "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/types": "8.11.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -3772,9 +3772,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "17.1.3",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.3.tgz",
-      "integrity": "sha512-4uDLBWPuDHT5KLieIJ20FoAB8yqJejmupI42wPyfObgQOBbPAikQSwT73afDwREvhuxYrRDqlRvxTMSfvO+L8A==",
+      "version": "17.1.4",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-17.1.4.tgz",
+      "integrity": "sha512-crOUeN2GngqlkRCFQ/zi1zsneWd9IGZgIfAWYGAuhYiPnfbBTmJBL7Yq1wI0e1dsW8CfWc+h348WmfCREqeOBA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@types/chai": "5.0.0",
     "@types/mocha": "10.0.9",
-    "@types/node": "22.7.5",
-    "@typescript-eslint/eslint-plugin": "8.9.0",
-    "@typescript-eslint/parser": "8.9.0",
+    "@types/node": "22.7.8",
+    "@typescript-eslint/eslint-plugin": "8.11.0",
+    "@typescript-eslint/parser": "8.11.0",
     "chai": "4.4.1",
     "clean-webpack-plugin": "4.0.0",
     "emojilib": "4.0.0",
@@ -77,7 +77,7 @@
     "webpack": "5.95.0",
     "webpack-cli": "5.1.4",
     "prettier": "3.3.3",
-    "npm-check-updates": "17.1.3"
+    "npm-check-updates": "17.1.4"
   },
   "engines": {
     "node": "20.16.0"


### PR DESCRIPTION
Npm packages upgrades available:

⬆️ @types/node                       22.7.5  →  22.7.8
⬆️ @typescript-eslint/eslint-plugin   8.9.0  →  8.11.0
⬆️ @typescript-eslint/parser          8.9.0  →  8.11.0
⬆️ npm-check-updates                 17.1.3  →  17.1.4