### PR TITLE
Make lib compatible with future node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "npm-check-updates": "17.1.14"
   },
   "engines": {
-    "node": "20.16.0"
+    "node": ">=20.16.0"
   }
 }


### PR DESCRIPTION
This change is necessary for future versions of nodes. otherwise it will give developers error  when they use newer version of node. (for example lts which is "22.13.1" now ).
 
error universal-emoji-parser@2.0.35: The engine "node" is incompatible with this module. Expected version "20.16.0". Got "22.13.1"