### PR TITLE
fix: expose DEFAULT_EMOJI_CDN to CommonJS consumers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,12 +123,12 @@ The runtime never imports from `emojilib` or `unicode-emoji-json` directly. Ever
 
 The public API of the package is defined by `src/index.ts` and consists of:
 
-| Export                                                                                             | Purpose                                                                                                                        |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `default` (`uEmojiParser`)                                                                         | Object exposing `parse`, `parseToHtml`, `parseToUnicode`, `parseToShortcode`, `getEmojiObjectByShortcode`, `getDefaultOptions` |
-| Named: `emojiLibJsonData`                                                                          | The full catalog as `EmojiLibJsonType` — read-only consumers                                                                   |
-| Named: `DEFAULT_EMOJI_CDN`                                                                         | Twemoji CDN URL string                                                                                                         |
-| CommonJS: `module.exports = uEmojiParser` and `module.exports.emojiLibJsonData = emojiLibJsonData` | Required for `require()` consumers                                                                                             |
+| Export                                                                                                                                                  | Purpose                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `default` (`uEmojiParser`)                                                                                                                              | Object exposing `parse`, `parseToHtml`, `parseToUnicode`, `parseToShortcode`, `getEmojiObjectByShortcode`, `getDefaultOptions` |
+| Named: `emojiLibJsonData`                                                                                                                               | The full catalog as `EmojiLibJsonType` — read-only consumers                                                                   |
+| Named: `DEFAULT_EMOJI_CDN`                                                                                                                              | Twemoji CDN URL string                                                                                                         |
+| CommonJS: `module.exports = uEmojiParser`, `module.exports.emojiLibJsonData = emojiLibJsonData`, `module.exports.DEFAULT_EMOJI_CDN = DEFAULT_EMOJI_CDN` | Required for `require()` consumers                                                                                             |
 
 Rules:
 
@@ -289,9 +289,10 @@ This package never hardcodes emoji-to-URL mappings — it delegates to `@twemoji
 export default uEmojiParser
 module.exports = uEmojiParser
 module.exports.emojiLibJsonData = emojiLibJsonData
+module.exports.DEFAULT_EMOJI_CDN = DEFAULT_EMOJI_CDN
 ```
 
-This is **intentionally redundant**. Webpack with `libraryTarget: 'commonjs2'` exposes the default export as `module.exports.default`, which breaks `require('universal-emoji-parser').parse(...)`. The two assignments at the bottom of `src/index.ts` reattach the API to `module.exports` itself so `require` users get the same shape as `import` users.
+This is **intentionally redundant**. Webpack with `libraryTarget: 'commonjs2'` exposes the default export as `module.exports.default`, which breaks `require('universal-emoji-parser').parse(...)`. The three assignments at the bottom of `src/index.ts` reattach the API and the named exports to `module.exports` itself so `require` users get the same shape as `import` users. **Every `export const` in `src/index.ts` must also be reattached here**, otherwise it ships as `undefined` to CommonJS consumers (covered by `test/exports.test.ts`).
 
 ### 6. CI-Driven Releases
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,9 +185,10 @@ Order matters: shortcode → unicode → HTML. Each stage is a no-op if its opti
 export default uEmojiParser
 module.exports = uEmojiParser
 module.exports.emojiLibJsonData = emojiLibJsonData
+module.exports.DEFAULT_EMOJI_CDN = DEFAULT_EMOJI_CDN
 ```
 
-Webpack's `libraryTarget: 'commonjs2'` exposes the default export as `module.exports.default`, which would break `require('universal-emoji-parser').parse(...)`. The two `module.exports` assignments at the bottom flatten the API so `require` and `import` users see the same shape.
+Webpack's `libraryTarget: 'commonjs2'` exposes the default export as `module.exports.default`, which would break `require('universal-emoji-parser').parse(...)`. The three `module.exports` assignments at the bottom flatten the API so `require` and `import` users see the same shape. Every `export const` declared at the top of `src/index.ts` must be reattached here too, otherwise it ships as `undefined` to CommonJS consumers (regression-tested in `test/exports.test.ts`).
 
 ## Type model — `src/lib/type.ts`
 

--- a/docs/RUNTIMES.md
+++ b/docs/RUNTIMES.md
@@ -53,6 +53,7 @@ The dual export shape is implemented in `src/index.ts`:
 export default uEmojiParser
 module.exports = uEmojiParser
 module.exports.emojiLibJsonData = emojiLibJsonData
+module.exports.DEFAULT_EMOJI_CDN = DEFAULT_EMOJI_CDN
 ```
 
 This means **both** `require('universal-emoji-parser').parse(...)` and `import uEmojiParser from '...'` give you the same object — see [Architecture → CommonJS reattachment](ARCHITECTURE.md#commonjs-reattachment).

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,4 @@ export default uEmojiParser
 // Exporting for CommonJS modules (require)
 module.exports = uEmojiParser
 module.exports.emojiLibJsonData = emojiLibJsonData
+module.exports.DEFAULT_EMOJI_CDN = DEFAULT_EMOJI_CDN

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,69 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { expect } from 'chai'
+import uEmojiParser, { DEFAULT_EMOJI_CDN, emojiLibJsonData } from '../src/index'
+
+const EXPECTED_METHODS: ReadonlyArray<keyof typeof uEmojiParser> = [
+  'parse',
+  'parseToHtml',
+  'parseToUnicode',
+  'parseToShortcode',
+  'getEmojiObjectByShortcode',
+  'getDefaultOptions',
+]
+
+describe('Public exports surface', () => {
+  describe('Source (src/index.ts)', () => {
+    it('exposes the documented methods on the default export', () => {
+      for (const method of EXPECTED_METHODS) {
+        expect(uEmojiParser[method], `default.${method}`).to.be.a('function')
+      }
+    })
+
+    it('exposes DEFAULT_EMOJI_CDN as a non-empty string', () => {
+      expect(DEFAULT_EMOJI_CDN).to.be.a('string')
+      expect(DEFAULT_EMOJI_CDN.length).to.be.greaterThan(0)
+    })
+
+    it('exposes emojiLibJsonData with the curated catalog', () => {
+      expect(emojiLibJsonData).to.be.an('object')
+      expect(Object.keys(emojiLibJsonData).length).to.be.greaterThan(1500)
+    })
+  })
+
+  describe('Built bundle (dist/index.js, CommonJS consumer shape)', () => {
+    const distPath = resolve(process.cwd(), 'dist/index.js')
+    let dist: Record<string, unknown> | null = null
+
+    before(function () {
+      // Skip when running against source only (e.g. test:watch without a build).
+      if (!existsSync(distPath)) {
+        this.skip()
+      }
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      dist = require(distPath) as Record<string, unknown>
+    })
+
+    it('reattaches DEFAULT_EMOJI_CDN onto module.exports for require() consumers', () => {
+      expect(dist).to.have.property('DEFAULT_EMOJI_CDN').that.is.a('string')
+      expect((dist!.DEFAULT_EMOJI_CDN as string).length).to.be.greaterThan(0)
+      expect(dist!.DEFAULT_EMOJI_CDN).to.equal(DEFAULT_EMOJI_CDN)
+    })
+
+    it('reattaches emojiLibJsonData onto module.exports for require() consumers', () => {
+      expect(dist).to.have.property('emojiLibJsonData').that.is.an('object')
+      expect(Object.keys(dist!.emojiLibJsonData as object).length).to.equal(Object.keys(emojiLibJsonData).length)
+    })
+
+    it('exposes all documented methods via require()', () => {
+      for (const method of EXPECTED_METHODS) {
+        expect(dist![method], `require()['${method}']`).to.be.a('function')
+      }
+    })
+
+    it('parse() works through the require() entry point', () => {
+      const html = (dist as { parse: (text: string) => string }).parse(':rocket:')
+      expect(html).to.match(/<img class="emoji" alt="🚀" src="https:\/\/.+1f680\.svg"\/>/)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`src/index.ts` reattached `emojiLibJsonData` onto `module.exports` but **not `DEFAULT_EMOJI_CDN`**. As a result:

- `require('universal-emoji-parser').DEFAULT_EMOJI_CDN` was **`undefined`** in published versions, even though `dist/index.d.ts` declares `export const DEFAULT_EMOJI_CDN: string` and `docs/API_REFERENCE.md` documents it as a public export.
- ESM consumers using `import { DEFAULT_EMOJI_CDN } from 'universal-emoji-parser'` got `SyntaxError: Named export 'DEFAULT_EMOJI_CDN' not found`.

This was caught by reproducing the npm install + import flow as a real consumer (CommonJS and ESM scripts under `tmp/consumer-test/`).

## Changes

- **`src/index.ts`**: reattach `DEFAULT_EMOJI_CDN` onto `module.exports`, next to `emojiLibJsonData`. **Behavior change is purely additive** — the value goes from `undefined` to the documented string.
- **`test/exports.test.ts`** (new): regression-tests the public surface against both the source (`src/index.ts`) and the built bundle (`require('dist/index.js')`). Self-skips the dist suite when `dist/` is absent so `npm run test:watch` remains zero-cost.
- **`AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/RUNTIMES.md`**: spell out the "every `export const` in `src/index.ts` must also be reattached on `module.exports`" rule and reference the regression test.

## Why this is non-breaking

- No method signatures or option defaults change.
- HTML output template is untouched.
- Catalog (`emojiLibJsonData`) is unchanged.
- The only runtime difference is a property going from `undefined` → its documented value. No reasonable consumer depends on `undefined`.

## Test plan

- [x] `npm run eslint:check`
- [x] `npm run prettier:check`
- [x] `npm run build:tsc`
- [x] `npm run build`
- [x] `npm test` — 22 specs passing (15 previous + 7 new), 1 pending (the `it.skip` regenerator).
- [x] Manual smoke: `node -e "console.log(require('./dist/index.js').DEFAULT_EMOJI_CDN)"` returns the CDN URL.

Made with [Cursor](https://cursor.com)