### PR TITLE
chore: make export-surface tests stale-dist resilient and CI-effective

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,12 @@ module.exports.emojiLibJsonData = emojiLibJsonData
 module.exports.DEFAULT_EMOJI_CDN = DEFAULT_EMOJI_CDN
 ```
 
-This is **intentionally redundant**. Webpack with `libraryTarget: 'commonjs2'` exposes the default export as `module.exports.default`, which breaks `require('universal-emoji-parser').parse(...)`. The three assignments at the bottom of `src/index.ts` reattach the API and the named exports to `module.exports` itself so `require` users get the same shape as `import` users. **Every `export const` in `src/index.ts` must also be reattached here**, otherwise it ships as `undefined` to CommonJS consumers (covered by `test/exports.test.ts`).
+This is **intentionally redundant**. Webpack with `libraryTarget: 'commonjs2'` exposes the default export as `module.exports.default`, which breaks `require('universal-emoji-parser').parse(...)`. The three assignments at the bottom of `src/index.ts` reattach the API and the named exports to `module.exports` itself so `require` users get the same shape as `import` users. **Every `export const` in `src/index.ts` must also be reattached here**, otherwise it ships as `undefined` to CommonJS consumers.
+
+`test/exports.test.ts` enforces this rule two ways:
+
+1. **Static check (always runs, no build needed)** — parses `src/index.ts` and asserts every `export const X` has a matching `module.exports.X = X`. Fails CI on PR with the exact line to add. This is the line of defense that runs in `code_check.yml` (which doesn't build before testing).
+2. **Bundle smoke test (runs when `dist/` is fresh)** — `require('./dist/index.js')` and asserts the same property at runtime. Self-skips with a clear hint if `dist/` is missing or older than `src/`, so `npm test` and `npm run test:watch` never fail spuriously when you forget to rebuild. The `codecheck` shell helper builds before testing, so this suite always exercises in the local pre-merge gate.
 
 ### 6. CI-Driven Releases
 

--- a/docker/custom_commands.sh
+++ b/docker/custom_commands.sh
@@ -68,7 +68,10 @@ function build() {
 	fi
 }
 
-# Same gates as CI: code_check.yml (eslint + prettier + test) plus build:tsc + webpack (pre-merge / pre-publish)
+# Same gates as CI plus build:tsc + webpack (pre-merge / pre-publish).
+# Order: lint/format -> build -> test. Build runs before test so the bundle suite
+# in test/exports.test.ts validates an up-to-date dist/index.js (otherwise it
+# self-skips with a hint).
 function codecheck() {
 	check
 	if [ $? != 0 ]; then
@@ -76,17 +79,17 @@ function codecheck() {
 		print.error "⚠️ Lint/format check failed."
 		return 1
 	fi
-	test
-	if [ $? != 0 ]; then
-		print.error "⚠️ Tests failed."
-		return 1
-	fi
 	build
 	if [ $? != 0 ]; then
 		print.error "⚠️ Build failed."
 		return 1
 	fi
-	print.success "✅ codecheck passed (eslint + prettier + test + build:tsc + webpack)"
+	test
+	if [ $? != 0 ]; then
+		print.error "⚠️ Tests failed."
+		return 1
+	fi
+	print.success "✅ codecheck passed (eslint + prettier + build:tsc + webpack + test)"
 }
 
 function install() {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, readFileSync, statSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
 import { expect } from 'chai'
 import uEmojiParser, { DEFAULT_EMOJI_CDN, emojiLibJsonData } from '../src/index'
 
@@ -11,6 +11,23 @@ const EXPECTED_METHODS: ReadonlyArray<keyof typeof uEmojiParser> = [
   'getEmojiObjectByShortcode',
   'getDefaultOptions',
 ]
+
+const repoRoot = process.cwd()
+const sourcePath = resolve(repoRoot, 'src/index.ts')
+const distPath = resolve(repoRoot, 'dist/index.js')
+
+function newestMtimeUnder(dir: string): number {
+  let newest = 0
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      newest = Math.max(newest, newestMtimeUnder(full))
+    } else if (entry.isFile()) {
+      newest = Math.max(newest, statSync(full).mtimeMs)
+    }
+  }
+  return newest
+}
 
 describe('Public exports surface', () => {
   describe('Source (src/index.ts)', () => {
@@ -29,15 +46,44 @@ describe('Public exports surface', () => {
       expect(emojiLibJsonData).to.be.an('object')
       expect(Object.keys(emojiLibJsonData).length).to.be.greaterThan(1500)
     })
+
+    /**
+     * Webpack's `commonjs2` output assigns `module.exports = uEmojiParser`, which wipes the
+     * named exports. Every `export const` in src/index.ts must therefore be reattached on
+     * `module.exports` manually, or it will arrive as `undefined` to `require()` consumers
+     * (and `import`'s named-export interop will also fail in Node ESM).
+     *
+     * Static analysis here so the rule is enforced even when CI runs `npm test` without a
+     * `dist/` build (the bundle suite below covers the same property at runtime).
+     */
+    it('reattaches every `export const` onto `module.exports` (static check)', () => {
+      const source = readFileSync(sourcePath, 'utf8')
+      const declaredExports = [...source.matchAll(/^\s*export\s+const\s+(\w+)/gm)].map((m) => m[1])
+      const reattachedExports = [...source.matchAll(/^\s*module\.exports\.(\w+)\s*=/gm)].map((m) => m[1])
+
+      const missing = declaredExports.filter((name) => !reattachedExports.includes(name))
+      expect(
+        missing,
+        `These named exports must be reattached at the bottom of src/index.ts:\n` +
+          missing.map((name) => `  module.exports.${name} = ${name}`).join('\n')
+      ).to.deep.equal([])
+    })
   })
 
   describe('Built bundle (dist/index.js, CommonJS consumer shape)', () => {
-    const distPath = resolve(process.cwd(), 'dist/index.js')
     let dist: Record<string, unknown> | null = null
 
     before(function () {
-      // Skip when running against source only (e.g. test:watch without a build).
       if (!existsSync(distPath)) {
+        // eslint-disable-next-line no-console
+        console.log('       (skipping bundle suite: dist/index.js not built — run `npm run build`)')
+        this.skip()
+      }
+      const distMtime = statSync(distPath).mtimeMs
+      const newestSrcMtime = newestMtimeUnder(resolve(repoRoot, 'src'))
+      if (distMtime < newestSrcMtime) {
+        // eslint-disable-next-line no-console
+        console.log('       (skipping bundle suite: dist/index.js is older than src/ — run `npm run build`)')
         this.skip()
       }
       // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
## Summary

The bundle suite added in #308 only validated `dist/index.js` when it existed. Two real problems followed:

1. **CI couldn't catch the very regression it was meant to catch.** `code_check.yml` runs `npm test` **without** first building, so the bundle suite always skipped in CI and the missing-`module.exports`-reattachment bug would not have been blocked at PR time.
2. **Local devs got confusing failures from stale `dist/`.** Switching branches or merging main left an older `dist/index.js` on disk; the test then failed with a dry assertion error instead of a hint.

## What this PR does

Three small, complementary fixes — minimal disruption, maximum coverage:

### 1. Static check, always runs (no build needed)

`test/exports.test.ts` now parses `src/index.ts` and asserts that every `export const X` has a matching `module.exports.X = X` reattachment. If a future PR adds a named export but forgets the reattachment, CI fails with the exact line(s) to add:

```
AssertionError: These named exports must be reattached at the bottom of src/index.ts:
  module.exports.MY_NEW_CONST = MY_NEW_CONST
```

This is the line of defense that **runs in `code_check.yml`**, even though that workflow doesn't build.

### 2. Bundle suite: skip-with-hint when missing or stale

The runtime suite that does `require('./dist/index.js')` now self-skips with a readable message when `dist/` is missing **or** older than the newest file in `src/`:

```
       (skipping bundle suite: dist/index.js is older than src/ — run `npm run build`)
```

No more spurious failures during `npm test:watch` or right after a merge.

### 3. `codecheck`: build before test

`docker/custom_commands.sh` runs `build` before `test` so the local pre-merge gate always exercises the bundle suite end-to-end.

## Verification

| Scenario                        | Result                                |
| ------------------------------- | ------------------------------------- |
| `rm -rf dist && npm test`       | Static check runs, bundle suite skips with hint |
| `npm run build && touch src/index.ts && npm test` | Static check runs, bundle suite skips with hint |
| `npm run build && npm test`     | All 23 specs pass                     |
| Mutation: delete one reattachment | Static check fails with actionable error |
| `codecheck`                     | Always runs build then test → 23/23 green |

## Test plan

- [x] `npm run eslint:check`
- [x] `npm run prettier:check`
- [x] `npm run build:tsc`
- [x] `npm run build`
- [x] `npm test` — 23 passing (all 4 bundle specs verified after build), 1 pending (`it.skip`'d regenerator)
- [x] Mutation test confirms the static check fails when a reattachment is removed

Made with [Cursor](https://cursor.com)