### PR TITLE
fix: parse :+1:, :-1: and :100: as on GitHub (closes #231)

### DIFF
--- a/.vscode_example/settings.json
+++ b/.vscode_example/settings.json
@@ -1,4 +1,13 @@
 {
+  "workbench.colorCustomizations": {
+    "titleBar.activeBackground": "#9d9700",
+    "titleBar.activeForeground": "#e2e8f0",
+    "activityBar.background": "#9d9700",
+    "statusBar.background": "#9d9700",
+    "statusBar.foreground": "#e2e8f0",
+    "sideBar.background": "#4a4700",
+    "sideBar.foreground": "#e2e8f0"
+  },
   "mocha.files.glob": "./test/**/*.ts",
   "mochaExplorer.files": "test/**/*.ts",
   "mochaExplorer.nodeArgv": ["--import", "tsx"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,14 +67,15 @@ const uEmojiParser: UEmojiParserType = {
     return this.__parseEmojiToHtml(text, emojiCDN)
   },
   parseToUnicode(text: string): string {
-    const emojisRegExp: RegExp = /:(\w+):/g
+    // Allow `+` and `-` so GitHub-style aliases like :+1: and :-1: parse.
+    const emojisRegExp: RegExp = /:([\w+-]+):/g
     const emojisShortcodesList: RegExpMatchArray | null = text.match(emojisRegExp)
     if (emojisShortcodesList) {
       emojisShortcodesList.forEach((shortcode: string) => {
         const emoji = this.getEmojiObjectByShortcode(shortcode)
         if (emoji) {
-          const regEx = new RegExp(shortcode)
-          text = text.replace(regEx, emoji.char)
+          // split/join replaces literal occurrences without regex metachar pitfalls (e.g. `+` in `:+1:`).
+          text = text.split(shortcode).join(emoji.char)
         }
       })
     }

--- a/src/lib/emoji-lib.json
+++ b/src/lib/emoji-lib.json
@@ -1667,7 +1667,7 @@
     "unicode_version": "0.6",
     "skin_tone_support": false,
     "char": "💯",
-    "keywords": ["hundred_points", "score", "perfect", "century", "exam", "quiz", "hundred", "keep"]
+    "keywords": ["hundred_points", "score", "perfect", "century", "exam", "quiz", "hundred", "100", "keep"]
   },
   "💢": {
     "name": "anger symbol",
@@ -10158,7 +10158,7 @@
     "unicode_version": "0.6",
     "skin_tone_support": false,
     "char": "🕐",
-    "keywords": ["one_o_clock", "1", "1:00", "100", "13:00", "1300", "clock1", "o’clock"]
+    "keywords": ["one_o_clock", "1", "1:00", "13:00", "1300", "early", "clock1", "o’clock"]
   },
   "🕜": {
     "name": "one-thirty",
@@ -10168,7 +10168,7 @@
     "unicode_version": "0.7",
     "skin_tone_support": false,
     "char": "🕜",
-    "keywords": ["one_thirty", "1:30", "130", "13:30", "1330", "early", "clock130"]
+    "keywords": ["one_thirty", "1:30", "130", "13:30", "1330", "clock130"]
   },
   "🕑": {
     "name": "two o’clock",

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -468,4 +468,28 @@ describe('Test emoji parser', () => {
       )
     })
   })
+
+  describe('GitHub-style aliases', () => {
+    it('should parse :+1: and :-1: shortcodes', () => {
+      // Regression for issue #231: the previous /:(\w+):/ regex did not match `+` or `-`,
+      // so common GitHub aliases were silently left as-is.
+      expect(uEmojiParser.parseToUnicode(':+1:')).to.be.equal('👍')
+      expect(uEmojiParser.parseToUnicode(':-1:')).to.be.equal('👎')
+      expect(uEmojiParser.parseToUnicode('lgtm :+1:')).to.be.equal('lgtm 👍')
+      expect(uEmojiParser.parseToUnicode(':+1: :+1:')).to.be.equal('👍 👍')
+    })
+
+    it('should resolve :100: to 💯', () => {
+      // Regression for issue #231: :100: previously fell back to 🕐 (one o'clock = 1:00)
+      // because "100" was a keyword on that emoji. Special-case override moves it to 💯.
+      expect(uEmojiParser.parseToUnicode(':100:')).to.be.equal('💯')
+    })
+
+    it('should render GitHub aliases through parse()', () => {
+      const result: string = uEmojiParser.parse('lgtm :+1: :100:')
+      expect(result).to.be.equal(
+        'lgtm <img class="emoji" alt="👍" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/svg/1f44d.svg"/> <img class="emoji" alt="💯" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/svg/1f4af.svg"/>'
+      )
+    })
+  })
 })

--- a/test/prepareEmojiLibJson.test.ts
+++ b/test/prepareEmojiLibJson.test.ts
@@ -28,6 +28,13 @@ describe('Prepare emoji parser assets', () => {
     '⏸️': {
       include: ['double_vertical_bar'],
     },
+    // GitHub/Slack/Discord render :100: as 💯; the upstream catalog associates "100" with 🕐 (1:00).
+    '💯': {
+      include: ['100'],
+    },
+    '🕐': {
+      exclude: ['100'],
+    },
   }
 
   /**


### PR DESCRIPTION
## Summary

Resolves [#231](https://github.com/DailybotHQ/universal-emoji-parser/issues/231) — three GitHub-style aliases that were silently broken now parse correctly:

- `:+1:` → 👍 and `:-1:` → 👎 (the previous `/:(\w+):/` regex didn't accept `+` or `-`)
- `:100:` → 💯 (previously fell back to 🕐 because `"100"` was a keyword on _one o'clock_ = 1:00)

Scope is intentionally minimal. The broader "multi-platform shortcode dialect" idea from the issue thread (catalog merged from `emojibase`/Slack/Discord/etc.) is **not** done — bundle-size cost and the `:pencil:` ambiguity (📝 vs ✏️) make it a poor trade-off for one user request over 22 months.

## Changes

| File | Change |
|---|---|
| `src/index.ts` | `parseToUnicode` regex now allows `+`/`-`; per-shortcode replacement uses `split/join` instead of `new RegExp(shortcode)` so regex metachars in `:+1:` aren't treated as syntax |
| `test/prepareEmojiLibJson.test.ts` | `EMOJIS_SPECIAL_CASES`: include `100` in 💯, exclude it from 🕐 |
| `src/lib/emoji-lib.json` | Regenerated. 3 entries affected (💯, 🕐, 🕜). `TOTAL_EMOJIS` unchanged at 1914 |
| `test/main.test.ts` | New `describe('GitHub-style aliases')` block with 3 specs |

> Also rides along: a pre-existing commit (`Update vscode`, +9 lines in `.vscode_example/settings.json`) that was already on the branch.

## Test plan

- [x] `npm run eslint:check` clean
- [x] `npm run prettier:check` clean
- [x] `npm run build:tsc` clean
- [x] `npm run build` (Webpack) clean
- [x] `npm test` — 26 passing, 1 pending (the regenerator, correctly `it.skip`'d)
- [x] Manual smoke: `:+1:`, `:-1:`, `:100:`, `lgtm :+1: :100:` all render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)