### PR TITLE
chore: update DeepWorkPlan skill to v2.5.0 + add docs/PRODUCT_SPEC.md

### DIFF
--- a/.agents/skills/deepworkplan/SKILL.md
+++ b/.agents/skills/deepworkplan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan
 description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, verify, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, manage, or verify structured multi-task work, or make a repository AI-agent-ready.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dailybot
 description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill and/or the Dailybot CLI, and wiring a best-effort progress/milestone report into DWP execution so a plan completion surfaces to the team. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dependency-upgrade
 description: Optional DeepWorkPlan addon that safely upgrades a repo's dependencies — reasoning about the repo's ACTUAL package manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer, and more) rather than assuming npm — with a batched, validated, revertible workflow that detects the manager and manifests/lockfiles, classifies upgrades (patch/minor/major), upgrades in safe batches, runs the repo's real validation gate after each batch, reverts a failing batch, and summarizes. Opt-in, never required, reconciles with the repo's existing tooling. Use when the developer wants to bring dependencies up to date without breaking the build.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-devcontainer
 description: Optional DeepWorkPlan addon that adds (or reconciles) a compose-based devcontainer to a repo — base image and supporting services reasoned from the detected stack, with persistent AI-CLI auth, the dailybot-project-network, the DOCKER_DEV_ENV=vscode convention, and project-identity precedence. Opt-in, never required, reconciles existing setups instead of clobbering them. Use when the developer wants a reproducible isolated dev container for an AI-first repo.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/author/SKILL.md
+++ b/.agents/skills/deepworkplan/author/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-author
 description: Author or update reusable skills, agents, and commands in the current repo — reason about the repo's .agents/ layout, follow the Open Agent Skills frontmatter contract, and keep the .agents/docs/ catalog in sync. Use when a developer wants to create or evolve the repo's agent kit (skills, agents, commands), or runs /skill-create or /agent-create.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/create/SKILL.md
+++ b/.agents/skills/deepworkplan/create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-create
 description: Create a Deep Work Plan. Gather context, draft, and refine into a single final plan under .dwp/plans/, with a refined draft staged in .dwp/drafts/. Use when the developer wants a new structured multi-task plan.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/execute/SKILL.md
+++ b/.agents/skills/deepworkplan/execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-execute
 description: Execute an existing Deep Work Plan task-by-task, run each task's validation, and log progress. Use when the developer wants to run or continue executing a plan in .dwp/plans/.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/onboard/SKILL.md
+++ b/.agents/skills/deepworkplan/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-onboard
 description: Make a repository AI-first by reasoning about its stack and archetype, then generating adapted AGENTS.md, docs/, per-module docs, .agents/, and the .claude to .agents symlink. Offers opt-in addons. Use when the developer wants to onboard or AI-enable a repo.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
@@ -70,8 +70,9 @@ When this flow finishes, the target repo contains:
    repo's **real, runnable** commands; plus `CLAUDE.md → AGENTS.md`.
 2. **`docs/`** — the standard categories, each filled with **real**
    repo-specific content (real commands, real module names, real test pattern):
-   `ARCHITECTURE.md`, `STANDARDS.md`, `TESTING_GUIDE.md`,
-   `DEVELOPMENT_COMMANDS.md`, `SECURITY.md`, `PERFORMANCE.md`,
+   `PRODUCT_SPEC.md` (the non-technical product/why doc — **required for every
+   repo, libraries included**), `ARCHITECTURE.md`, `STANDARDS.md`,
+   `TESTING_GUIDE.md`, `DEVELOPMENT_COMMANDS.md`, `SECURITY.md`, `PERFORMANCE.md`,
    `AI_AGENT_ONBOARDING.md`, `AI_AGENT_COLLAB.md`, optional
    `PR_REVIEW_WORKFLOW.md` / `ECOSYSTEM_CONTEXT.md`, and a `docs/README.md`
    index.
@@ -237,7 +238,7 @@ Never duplicate `AGENTS.md` content into `CLAUDE.md`.
 
 Produce the standard categories, **each adapted** from recon — an empty or
 generic doc is a failure. The conformance floor (all **MUST**):
-`ARCHITECTURE.md`, `STANDARDS.md`, `TESTING_GUIDE.md`,
+`PRODUCT_SPEC.md`, `ARCHITECTURE.md`, `STANDARDS.md`, `TESTING_GUIDE.md`,
 `DEVELOPMENT_COMMANDS.md`, `SECURITY.md`, `AI_AGENT_ONBOARDING.md`,
 `AI_AGENT_COLLAB.md`. **SHOULD**: `PERFORMANCE.md`, plus optional
 `PR_REVIEW_WORKFLOW.md` and `ECOSYSTEM_CONTEXT.md`. Always add a
@@ -245,6 +246,16 @@ generic doc is a failure. The conformance floor (all **MUST**):
 
 Each doc must contain **real** content:
 
+- `PRODUCT_SPEC.md` — the non-technical product/why doc: the problem the repo
+  solves, who it is for, its key capabilities/features, success criteria, and
+  explicit non-goals. It **MUST read plainly enough that anyone — a person or an
+  agent, technical or not — can understand what this repository is and why it
+  exists at a glance**; that is the whole point of the document. Reason it from
+  the README, package description, public API, and any roadmap/issues — never a
+  generic stub. **Required for every repo, including libraries, CLIs, and
+  internal tools**: if there are no end users, frame the product as its
+  consumers (who calls this API, and why they choose it). This is the *why*; the
+  docs below are the *how*.
 - `ARCHITECTURE.md` — the real components, data flow, and deployment shape from
   recon; an annotated diagram of the actual module layout.
 - `STANDARDS.md` — the repo's real coding conventions, naming, import order,
@@ -437,7 +448,8 @@ After generating, run this checklist in the target repo. On any failure,
 2. **`CLAUDE.md` resolves to `AGENTS.md`** — the symlink points at `AGENTS.md`,
    or `CLAUDE.md` contains exactly `@AGENTS.md`.
 3. **`docs/` has the standard categories**, each non-empty and repo-specific
-   (the seven MUST files at minimum, plus `docs/README.md`). Grep for leftover
+   (the eight MUST files at minimum — `PRODUCT_SPEC` included — plus
+   `docs/README.md`). Grep for leftover
    placeholder markers (`<...>`, "TODO", "your command here") and fix any.
 4. **Every major source module has a `README.md`** (and complex modules have a
    `docs/`).

--- a/.agents/skills/deepworkplan/refine/SKILL.md
+++ b/.agents/skills/deepworkplan/refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-refine
 description: Refine a Deep Work Plan draft or modify an existing final plan. Use when the developer wants to adjust scope, tasks, or details of a draft in .dwp/drafts/ or a plan in .dwp/plans/.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/resume/SKILL.md
+++ b/.agents/skills/deepworkplan/resume/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-resume
 description: Resume an interrupted Deep Work Plan from its recorded progress state. Use when the developer wants to continue a plan in .dwp/plans/ that was paused or interrupted mid-execution.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
+++ b/.agents/skills/deepworkplan/spec/DOCUMENTATION_STANDARD.md
@@ -140,12 +140,14 @@ commands are repo-specific (§7).
 
 A conformant repository **MUST** maintain a root-level `docs/` folder holding
 categorized markdown guides. Guides **SHOULD NOT** carry YAML frontmatter (they are
-evergreen reference, not lifecycle documents). The audit found the following
-**10 categories** common across the 6 repos; this set is the normative `docs/`
+evergreen reference, not lifecycle documents). The audit found 10 categories
+common across the 6 repos; this standard adds an 11th — **`PRODUCT_SPEC.md`**,
+the product/"why" layer — for **11 categories** total as the normative `docs/`
 standard:
 
 | # | Category file | Requirement | Purpose |
 |---|---------------|-------------|---------|
+| 0 | `PRODUCT_SPEC.md` | **MUST** | The product spec: the problem the repo solves, who it is for, its key capabilities/features, success criteria, and explicit non-goals — the **why** and **for whom**, not the **how**. Deliberately **non-technical**, high-value context. **Every repository is a product** — even a library, CLI, or internal tool: its consumers and their use cases are its product, and they deserve a non-technical spec. A library that omits this hides the very thing a new agent (or human) most needs to understand first. |
 | 1 | `ARCHITECTURE.md` | **MUST** | System design, components, data flow, key decisions. |
 | 2 | `STANDARDS.md` | **MUST** | Coding conventions, naming, import order, error/logging patterns, forbidden anti-patterns. |
 | 3 | `TESTING_GUIDE.md` | **MUST** | Test framework, file-naming pattern, how to run/scope tests, coverage expectation. |
@@ -157,8 +159,9 @@ standard:
 | 9 | `PR_REVIEW_WORKFLOW.md` | **SHOULD** | How PRs are opened, reviewed, and merged in this repo. |
 | 10 | `ECOSYSTEM_CONTEXT.md` | **SHOULD** (individual) / **MUST** (orchestrator hub & multi-repo members) | How this repo relates to sibling repos and the wider product. |
 
-- The five **MUST** categories (`ARCHITECTURE`, `STANDARDS`, `TESTING_GUIDE`, `DEVELOPMENT_COMMANDS`, `SECURITY`) plus `AI_AGENT_ONBOARDING` and `AI_AGENT_COLLAB` constitute the conformance floor for an AI-first repo.
-- A repository **MAY** add domain-specific guides beyond these 10 (e.g. `API_REFERENCE.md`, `DATABASE_SCHEMA.md`, `LOGGING_BEST_PRACTICES.md`, `REDIS_CACHING_BEST_PRACTICES.md`) when the stack warrants. Whether a given domain guide is warranted is part of the **repo-specific 10%** (§7). (All four examples observed live in `api-services/docs/`.)
+- The **MUST** categories (`PRODUCT_SPEC`, `ARCHITECTURE`, `STANDARDS`, `TESTING_GUIDE`, `DEVELOPMENT_COMMANDS`, `SECURITY`) plus `AI_AGENT_ONBOARDING` and `AI_AGENT_COLLAB` constitute the conformance floor for an AI-first repo.
+- `PRODUCT_SPEC.md` is **non-technical by design** and **MUST NOT** be skipped on the grounds that "this repo is just a library/tool." If the repo genuinely has no end users, frame the product as its API/consumers: what it offers, to whom, and why they would choose it. Reason the content from the real repo (README, package description, public API, issues/roadmap) — never a generic stub.
+- A repository **MAY** add domain-specific guides beyond these 11 (e.g. `API_REFERENCE.md`, `DATABASE_SCHEMA.md`, `LOGGING_BEST_PRACTICES.md`, `REDIS_CACHING_BEST_PRACTICES.md`) when the stack warrants. Whether a given domain guide is warranted is part of the **repo-specific 10%** (§7). (All four examples observed live in `api-services/docs/`.)
 - A guide that would fall below ~30 lines **SHOULD** be merged into a sibling; a guide above ~700 lines **SHOULD** be split into a subfolder.
 
 > **Divergence from v1.** v1 required only 5 `docs/` files at "Silver"
@@ -168,6 +171,15 @@ standard:
 > **MUST**, and renames `SETUP.md`→`DEVELOPMENT_COMMANDS.md` to match observed
 > practice (`RECONCILIATION.md` §"Specs"). `SETUP`/`TROUBLESHOOTING` content is
 > not lost: it folds into `DEVELOPMENT_COMMANDS.md` and `AI_AGENT_ONBOARDING.md`.
+>
+> **Added: `PRODUCT_SPEC.md` (category 0, MUST).** The audited 10-category set was
+> entirely engineering/process documentation — it captured the *how* but never the
+> *why*. This standard adds `PRODUCT_SPEC.md` as a required, deliberately
+> **non-technical** product/purpose document so an agent (or human) learns what the
+> repo is *for* and *for whom* before diving into its mechanics. It is a **MUST for
+> every archetype, including libraries, CLIs, and internal tools** — every
+> repository is a product; the spec frames its users/consumers and the value it
+> delivers.
 
 ### 3.2. `docs/README.md` Master Index
 
@@ -316,7 +328,9 @@ the classification heuristic and the full onboarding-difference matrix.
 The v1 Bronze/Silver/Gold/Platinum badge ladder is retained as an **informative**
 self-assessment aid, not a normative requirement. A repository is **AI-first
 conformant** when it satisfies every **MUST** in §§2–7. The optional ladder maps,
-roughly: Bronze = §2 only; Silver = §2 + the five MUST `docs/` categories; Gold =
+roughly: Bronze = §2 only; Silver = §2 + the six MUST `docs/` categories
+(`PRODUCT_SPEC`, `ARCHITECTURE`, `STANDARDS`, `TESTING_GUIDE`,
+`DEVELOPMENT_COMMANDS`, `SECURITY`); Gold =
 + remaining MUST categories + `.agents/` + symlinks; Platinum = + per-module docs
 for all complex modules (§4).
 

--- a/.agents/skills/deepworkplan/status/SKILL.md
+++ b/.agents/skills/deepworkplan/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-status
 description: Report the status of a Deep Work Plan — completed tasks, what's left, and blockers — without executing. Use when the developer asks for plan status or what remains.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/verify/SKILL.md
+++ b/.agents/skills/deepworkplan/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-verify
 description: Verify that a repository is DeepWorkPlan-conformant (AI-first) and that its plans are well-formed, producing an objective pass/fail report. Use when the developer asks to verify, audit, or check conformance of a repo or a plan.
-version: "2.4.0"
+version: "2.5.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob
@@ -48,7 +48,7 @@ test -f AGENTS.md && grep -qiE 'quick commands|## commands' AGENTS.md && echo "A
 
 # 3. docs/ with the standard categories
 test -d docs && echo "docs/: present" || echo "docs/: FAIL"
-for d in ARCHITECTURE STANDARDS TESTING_GUIDE DEVELOPMENT_COMMANDS SECURITY AI_AGENT_ONBOARDING; do
+for d in PRODUCT_SPEC ARCHITECTURE STANDARDS TESTING_GUIDE DEVELOPMENT_COMMANDS SECURITY AI_AGENT_ONBOARDING; do
   ls docs/ 2>/dev/null | grep -qi "$d" && echo "  docs/$d: ok" || echo "  docs/$d: missing"
 done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 
 | Category        | Guide                                                                                           | Purpose                                                                        |
 | --------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Product         | [Product Spec](docs/PRODUCT_SPEC.md)                                                            | Non-technical "why" and "for whom": problem, audience, capabilities, non-goals |
 | Architecture    | [Architecture](docs/ARCHITECTURE.md)                                                            | Module layout, data flow, parse pipeline, emoji catalog                        |
 | Technologies    | [Technologies](docs/TECHNOLOGIES.md)                                                            | Stack overview with versions and roles                                         |
 | Standards       | [Standards](docs/STANDARDS.md)                                                                  | TypeScript / lint / Prettier conventions, naming, exports                      |

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -1,0 +1,96 @@
+# Product Spec — Universal Emoji Parser
+
+> The non-technical "why" and "for whom" of this repository. Read this first to
+> understand what the project is and the value it delivers, before the _how_ in
+> the other guides.
+
+## The problem
+
+Emoji look different on every platform, and they arrive in text in inconsistent
+forms. The same idea might appear as a raw unicode character (`😎`) or as one of
+several competing shortcode dialects (`:smiling_face_with_sunglasses:` on one
+platform, `:sunglasses:` on another). When an application renders that text, the
+result depends on the user's operating system and font — so the same message can
+look different, broken, or blank for different readers. Teams that aggregate
+messages from many sources (chat, forms, comments) need emoji to render the
+**same way for everyone**, and need to translate freely between unicode and
+shortcode forms.
+
+## What this product is
+
+**Universal Emoji Parser** is an open-source ([MIT](../LICENSE)) JavaScript/
+TypeScript library, published on npm as
+[`universal-emoji-parser`](https://www.npmjs.com/package/universal-emoji-parser).
+Given any text, it finds the emoji inside it and converts them:
+
+- **unicode or shortcode → HTML** `<img>` tags backed by the
+  [Twemoji](https://github.com/jdecked/twemoji) CDN, so emoji render identically
+  in every browser regardless of the user's device;
+- **between forms** — shortcode → unicode, or unicode → shortcode.
+
+It ships a single curated emoji dictionary so it recognizes the shortcode
+dialects used by **Twitter, GitHub, Slack, Discord, Google Chat, and Microsoft
+Teams** through one normalized catalog.
+
+## Who it is for
+
+This is a library, so its "users" are the **developers and applications that
+consume it** — and the end users they serve:
+
+- **Application & product developers** who display user-generated text and want
+  consistent, accessible emoji rendering without shipping their own emoji assets.
+- **Chat, messaging, and collaboration tools** (the original driver: DailyBot)
+  that ingest text from multiple platforms and must normalize emoji across them.
+- **Content and CMS pipelines** that transform text to HTML and want emoji to
+  survive that transformation cleanly.
+- **Both runtimes:** Node.js services (server-side rendering, message
+  processing) and browser apps (it bundles via webpack/rollup/vite), with dual
+  CommonJS and ES Module entry points.
+
+## Why they choose it
+
+- **Cross-platform consistency** — Twemoji-backed images look the same
+  everywhere, sidestepping OS/font differences.
+- **One dictionary, many dialects** — Slack-style (`:thumbsup:`) and canonical
+  (`:thumbs_up:`) shortcodes both resolve to the same emoji.
+- **Accessibility & copy-paste preserved** — rendered images keep the real
+  unicode emoji in their `alt` text.
+- **Drop-in and tiny surface** — a small, stable API (`parse`, `parseToHtml`,
+  `parseToUnicode`, `parseToShortcode`, …) and a single runtime dependency.
+- **Configurable CDN** — point emoji images at a custom/self-hosted CDN when
+  needed.
+
+## Key capabilities
+
+- Parse a string and replace every emoji with a consistent HTML `<img>` tag.
+- Convert text from shortcodes to unicode, or from unicode to shortcodes.
+- Resolve a shortcode (across supported dialects) to its emoji object.
+- Override the emoji image CDN for self-hosting or pinning.
+
+## Success criteria
+
+- A consumer can render emoji that look the same across browsers and devices.
+- Common shortcode dialects from the six supported platforms resolve correctly.
+- The public API and HTML output contract stay stable across non-major releases,
+  so upgrades don't break consumers' rendered output.
+- The package stays lightweight enough to bundle into browser applications.
+
+## Non-goals
+
+- **Not an emoji picker / UI component** — it transforms text; it renders no
+  interactive widget.
+- **Not an emoji image host** — it delegates image URLs to the Twemoji CDN (or a
+  CDN you configure); it ships no image assets of its own.
+- **Not a general Markdown or rich-text processor** — it only touches emoji,
+  leaving the surrounding text untouched.
+- **Not a moderation/sanitization tool** — it transforms text the consuming app
+  already considers safe; it does not HTML-escape surrounding content.
+- **Not a per-emoji metadata database** — the catalog carries only what parsing
+  needs (canonical slug + keywords), to keep the bundle small.
+
+---
+
+_The mechanics behind these goals live in the rest of [`docs/`](README.md):
+[ARCHITECTURE.md](ARCHITECTURE.md) for design, [API_REFERENCE.md](API_REFERENCE.md)
+for the public surface, and [EMOJI_PROVIDERS.md](EMOJI_PROVIDERS.md) for CDN and
+dialect details._

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,12 @@ shortcodes in text and converts them to Twemoji-backed HTML `<img>` tags, or
 between unicode and shortcode forms. It ships dual CommonJS + ESM entry points
 and targets Node ≥ 20.19 and bundled browser environments.
 
+## Product
+
+| Guide                              | Purpose                                                                            |
+| ---------------------------------- | ---------------------------------------------------------------------------------- |
+| [PRODUCT_SPEC.md](PRODUCT_SPEC.md) | The non-technical "why" and "for whom": problem, audience, capabilities, non-goals |
+
 ## Core guides
 
 | Guide                                              | Purpose                                                                        |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "688847e28d459ff31c48999df58dc7b60945724cf7bb61296f40d976ced12849"
+      "computedHash": "7f00ff227f7ca11ca3432001b013e667c9265454789dc395e54900e5e2442f24"
     }
   }
 }


### PR DESCRIPTION
## What & why

Re-ran the DeepWorkPlan onboarding (`https://deepworkplan.com/init.md`) after the skill was updated upstream. The DWP onboard flow is idempotent, so this only **updates the skill** and **fills the single new conformance gap** it introduced.

## Skill update

- `deepworkplan` skill: verify/onboard **v2.4.0 → v2.5.0**, hash `688847…` → `7f00ff…` (re-pinned in `skills-lock.json`).
- The update edited internal `SKILL.md`/`spec` text only — **no new files**, and the `dwp-*` command-templates are unchanged, so the repo's six thin delegators stay in sync (no drift).

## New conformance requirement reconciled

v2.5.0 adds **`PRODUCT_SPEC.md`** as a required (MUST) `docs/` category — a deliberately **non-technical** product/"why" document, mandatory for every repo *including libraries*.

- **`docs/PRODUCT_SPEC.md`** (new) — reasoned from the real README, package description, and public API: the problem, who it's for (consumers/integrators), why they choose it, key capabilities, success criteria, and explicit non-goals. Not a generic stub.
- **`docs/README.md`** + **`AGENTS.md`** doc index — link the new guide (added a "Product" row).

## Verification

- `npm test` → 22 passing, 5 pending (expected `it.skip` specs)
- `npm run eslint:check` → clean
- `npm run prettier:check` → clean (vendored skill pack excluded via existing `.prettierignore`)
- `npm run build:tsc` → compiles
- Docs conformance floor — 8 MUST categories incl. `PRODUCT_SPEC` + `docs/README.md` index → **CONFORMANT**

🤖 Generated with [Claude Code](https://claude.com/claude-code)