### PR TITLE
fix: ship only dist/ in the npm package (exclude AI-agent + docs artifacts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "eslint:check": "eslint .",
     "eslint:fix": "eslint . --fix",


### PR DESCRIPTION
## Problem

The DeepWorkPlan onboarding added `.agents/` (incl. a ~572 KB vendored skill pack), `docs/`, `AGENTS.md`, `skills-lock.json`, `.prettierignore`, `tmp/` and more at the repo root. Publishing relied on a **denylist** `.npmignore`, which doesn't catch new files — so all of this leaked into the npm tarball:

- Before: **138 files / 1.4 MB unpacked** — agent tooling + docs shipped to every consumer's `node_modules`.

## Fix

Switch to a **`files` allowlist** in `package.json` (`"files": ["dist"]`). npm always also includes `package.json`, `README.md`, and `LICENSE`, so the consumable API is unchanged.

- After: **10 files** — `dist/` + README + LICENSE + package.json only.

A `files` allowlist is robust against future root-level additions (a denylist is exactly what let these artifacts leak in).

## Verification

`npm pack --dry-run` → 10 files. `eslint:check`, `prettier:check`, `npm test` all green.

## Not the cause of the current release failure

The failing release (run 27069621435) is an **npm auth** problem — `npm publish` returned `404` (npm's masked "unauthorized") for an existing public package, and the registry is stuck at `2.1.2` while git/tags are at `2.1.4`. That points to an expired/invalid **`NPM_TOKEN`** secret and must be fixed separately (rotate the token). This PR just ensures the package stays lean once publishing is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)