### PR TITLE
docs: fix outdated Twemoji CDN URL in README (deploy pipeline test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ or
 
 ```
 → uEmojiParser.parse(':rocket:')
-<img class="emoji" alt="🚀" src="https://twemoji.maxcdn.com/v/12.1.2/72x72/1f680.svg"/>
+<img class="emoji" alt="🚀" src="https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/svg/1f680.svg"/>
 ```
 
 ```


### PR DESCRIPTION
## What

The `:rocket:` example in the README pointed at the legacy `twemoji.maxcdn.com` host, while every other example and the documented `DEFAULT_EMOJI_CDN` use the jsdelivr/jdecked Twemoji CDN. This aligns it.

## Why

A genuine, minimal change to **exercise the release/deploy pipeline end to end** — confirming `npm publish` succeeds now that the `NPM_TOKEN` has been refreshed.

On merge, the release workflow will `npm version patch` (2.1.5 → **2.1.6**), tag, create the GitHub release, and publish to npm. The package now ships only `dist/` (10-file tarball) thanks to #315.

## Verification

`prettier:check` green. Docs-only change; no code/API impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)