### PR TITLE
chore: update DeepWorkPlan skill to v2.7.0 (verified)

### DIFF
--- a/.agents/skills/deepworkplan/SKILL.md
+++ b/.agents/skills/deepworkplan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan
 description: DeepWorkPlan — turn any repo AI-first and run Deep Work Plans. Routes to create, execute, refine, resume, status, verify, and repo-onboarding sub-skills based on intent. Use when the developer wants to plan, execute, manage, or verify structured multi-task work, or make a repository AI-agent-ready.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/README.md
+++ b/.agents/skills/deepworkplan/addons/README.md
@@ -63,11 +63,13 @@ An addon MAY additionally ship per-stack presets, examples, or migration notes.
 | Devcontainer support | [`addons/devcontainer/`](devcontainer/SKILL.md) | **Authored** — compose-based `.devcontainer/` + `docker/` with AI-CLI persistence, `dailybot-project-network`, `DOCKER_DEV_ENV=vscode`, project-identity precedence, public-OSS variant, 7 reasoning presets. |
 | Dailybot integration | [`addons/dailybot/`](dailybot/SKILL.md) | **Authored** — opt-in install of the Dailybot agent skill / CLI, auth **deferred** to the Dailybot skill's own consent flow, and an **optional, best-effort, never-blocking** progress/milestone report wired into DWP execution (a plan completion → a Dailybot milestone report). The core methodology has **zero** Dailybot dependency. |
 | Dependency upgrade | [`addons/dependency-upgrade/`](dependency-upgrade/SKILL.md) | **Authored** — opt-in, **package-manager-agnostic** dependency upgrades: detect the repo's real manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer…), classify by semver, upgrade in safe batches, run the repo's **real** validation gate after each batch, revert a failing batch, summarize. Installs a `/lib-upgrade` delegator into the repo's `.agents/commands/` only when accepted. |
+| Design system | [`addons/design-system/`](design-system/SKILL.md) | **Authored** — opt-in, **frontend-scoped** `DESIGN.md` at `docs/DESIGN.md` (indexed from `AGENTS.md`; root only if no `docs/` tree): reason about the repo's **real** design tokens (CSS vars / Tailwind config / token files / component styles), document the canonical sections (colors & roles, typography, layout, elevation, shapes, components, responsive, do's & don'ts, agent prompt guide), check **WCAG AA** contrast + token integrity, reconcile an existing `DESIGN.md` instead of clobbering it. Offered by `onboard` **only when a UI surface / design system is detected**. |
 
 > This README is the mechanism doc. The first addon, `addons/devcontainer/`, is
 > the methodology's proof that the mechanism works; the second,
 > `addons/dailybot/`, shows an addon can layer optional team visibility while
 > keeping the methodology fully vendor-neutral; the third,
 > `addons/dependency-upgrade/`, shows an addon can encode a recurring maintenance
-> workflow that reasons about each repo's actual stack (a repo is conformant with
-> zero addons).
+> workflow that reasons about each repo's actual stack; the fourth,
+> `addons/design-system/`, shows an addon can capture durable, repo-native UI
+> design context for frontend repos (a repo is conformant with zero addons).

--- a/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dailybot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dailybot
 description: Optional DeepWorkPlan addon that connects an AI-first repo to the developer's Dailybot team — installing (with consent) the Dailybot agent skill and/or the Dailybot CLI, and wiring a best-effort progress/milestone report into DWP execution so a plan completion surfaces to the team. Opt-in, never required, never blocks the work, reconciles existing setups instead of clobbering them, and defers all auth to the Dailybot skill's own consent flow. Use when the developer or team already uses Dailybot and wants DWP progress visible to humans.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/dependency-upgrade/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-dependency-upgrade
 description: Optional DeepWorkPlan addon that safely upgrades a repo's dependencies — reasoning about the repo's ACTUAL package manager (npm/pnpm/yarn + ncu, pip/poetry/uv, cargo, go mod, bundler, composer, and more) rather than assuming npm — with a batched, validated, revertible workflow that detects the manager and manifests/lockfiles, classifies upgrades (patch/minor/major), upgrades in safe batches, runs the repo's real validation gate after each batch, reverts a failing batch, and summarizes. Opt-in, never required, reconciles with the repo's existing tooling. Use when the developer wants to bring dependencies up to date without breaking the build.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/addons/design-system/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/design-system/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: deepworkplan-addon-design-system
+description: Optional DeepWorkPlan addon that gives a frontend/UI repo a DESIGN.md (under docs/, indexed from AGENTS.md) — a Markdown design-system file any coding agent reads to generate UI consistent with the repo's OWN design system. Reasons about the repo's ACTUAL design tokens (CSS custom properties, Tailwind config, token files, component styles) rather than copying a brand file; documents colors & roles, typography, spacing/layout, elevation, shapes, components, responsive behavior, do's & don'ts, and an agent prompt guide; checks contrast (WCAG AA) and token integrity. Frontend-scoped and default-on when a UI/design system is detected (applied in trust mode, strongly recommended in guided mode; never offered for backend/CLI/library-only repos); never required for baseline conformance; reconciles an existing DESIGN.md instead of clobbering it. Use when the developer wants agents to produce on-brand, consistent UI for a frontend repo.
+version: "2.7.0"
+documentation_url: https://deepworkplan.com
+user-invocable: true
+allowed-tools: Bash, Read, Grep, Glob, Edit, Write
+metadata: {"openclaw":{"emoji":"🎨","homepage":"https://deepworkplan.com"}}
+---
+
+# DeepWorkPlan — Design-System Addon
+
+Give a **frontend/UI repo** a **`DESIGN.md`** — living under **`docs/`** alongside
+the repo's other specs and **indexed from `AGENTS.md`** — so any human or AI agent
+generates UI that matches the repo's **own** design system, instead of the
+unstyled, statistically-common defaults an agent falls back to with no guidance.
+This is an **opt-in addon** — it is **never** required for a repo to be AI-first,
+and it is **only** for repos with a real UI surface.
+
+> ## The rule that overrides everything: REASON about the repo's tokens, then write
+>
+> A `DESIGN.md` is only useful if it reflects **this** repo. The first job is to
+> **read the repo's real design source** — its stylesheet, CSS custom properties,
+> Tailwind config, token files, and component styles (see `SPEC.md` §3–§5 and
+> `templates/presets.md`) — then document those values. **Never paste a
+> third-party brand's `DESIGN.md`** (a Stripe/Linear/etc. catalog entry) into the
+> target repo: reference catalogs are inspiration for *structure*, never content.
+
+## Read these first (all relative inside the skill)
+
+- [`SPEC.md`](SPEC.md) — the normative (RFC-2119) contract: frontend-scope gate,
+  canonical sections, reason-don't-copy, reconcile-don't-clobber, accessibility &
+  token integrity, pragmatic-reference posture, validation step.
+- [`templates/DESIGN.md.md`](templates/DESIGN.md.md) — the annotated `DESIGN.md`
+  skeleton (each canonical section + how to fill it from the repo). The *shape* is
+  fixed; the *content* is reasoned per repo.
+- [`templates/presets.md`](templates/presets.md) — per-stack **reasoning presets**
+  (Tailwind, CSS-variables/vanilla, component-library/design-tokens) — where to
+  find tokens in each stack. A *starting checklist*, not an answer key —
+  **detected reality wins**.
+- [`templates/agent_prompt_guide.md`](templates/agent_prompt_guide.md) — the
+  "Agent Prompt Guide" block to embed so downstream agents know how to follow
+  `DESIGN.md`.
+- [`templates/design-system-command.md`](templates/design-system-command.md) — the
+  **optional** `/design-system` delegator this addon MAY install into the target
+  repo's `.agents/commands/` (only when accepted and wanted).
+- `../README.md` — the addon mechanism (opt-in, reconcile-don't-clobber, contract).
+
+## When this runs
+
+- From **`onboard` Phase 7b** — after the core AI-first scaffolding. This addon is
+  **default-on when detected** (`SPEC.md` §3.1): when a frontend/UI surface **is**
+  detected, `onboard` **applies** it in trust mode (and **strongly recommends** it
+  in guided mode); when no UI surface is detected it is **not** offered. Either way
+  the developer may decline and the repo stays baseline-conformant.
+- **Directly** — `/deepworkplan-addon-design-system` on an already-onboarded repo
+  to create or refresh `DESIGN.md`, or via the installed `/design-system`
+  delegator if one was added.
+
+## The flow
+
+### Step 0 — Consent + frontend-scope gate
+1. Confirm the developer wants a `DESIGN.md` (skip silently if declined — the repo
+   stays baseline-conformant).
+2. **Confirm the repo has a UI surface** (`SPEC.md` §3): look for stylesheets / CSS
+   custom properties, a Tailwind config or `@theme` block, UI components
+   (`.tsx`/`.vue`/`.svelte`/`.astro`), or a token/brand source. If there is **no**
+   UI surface, **stop** and tell the developer this addon does not apply.
+
+### Step 1 — Locate the design source (the part you MUST reason about)
+Find where this repo's design values actually live, using `templates/presets.md`:
+
+- **Tailwind** → `tailwind.config.*` or a Tailwind v4 `@theme {}` block in CSS:
+  theme colors, font families, spacing, radius, screens.
+- **CSS variables / vanilla** → `:root { --… }` custom properties in the global
+  stylesheet; spacing/size scales; media-query breakpoints.
+- **Component library / design tokens** → a `tokens.*` / `theme.*` export, a
+  design-tokens JSON, or a Storybook/theme file.
+- **Brand/style guide** → any `BRAND*.md` / `STYLE*.md` doc, plus accessibility
+  rules documented in `AGENTS.md`/`CLAUDE.md`.
+
+A repo MAY combine sources (a Tailwind config + a brand doc + CSS vars). Read all
+that exist; **the real files win** over any preset assumption.
+
+### Step 2 — Reason out each canonical section
+Using `templates/DESIGN.md.md`, fill each section from the design source:
+Overview/atmosphere · Color palette & roles (light + dark) · Typography · Layout &
+spacing · Elevation & depth · Shapes/radius · Components (in terms of the tokens) ·
+Responsive behavior · Do's & don'ts (incl. the repo's accessibility rules) · Agent
+prompt guide. Express values as **named tokens with usage notes**; add a
+machine-readable token block only if the repo already maintains structured tokens.
+Flag any value you had to **infer** so a human can confirm it.
+
+### Step 3 — Write or reconcile `DESIGN.md`, then index it in `AGENTS.md`
+- Choose the location (`SPEC.md` §2): if the repo has a `docs/` tree (DWP-native),
+  write **`docs/DESIGN.md`** alongside the other specs; if it has no `docs/` tree,
+  write `./DESIGN.md` at the root.
+- If no `DESIGN.md` exists → write it at the chosen location.
+- If one already exists → **reconcile additively** (`SPEC.md` §6): keep working
+  values, add missing canonical sections, and ask before any destructive change.
+- **Index it in `AGENTS.md`** (and therefore `CLAUDE.md`): add a reference to
+  `DESIGN.md` in the documentation index so agents discover it like the other
+  `docs/` specs. This pointer — not the physical location — is what guarantees
+  discovery (`SPEC.md` §2).
+
+### Step 4 — Validate (the gate)
+Run the validation step (`SPEC.md` §11):
+- `DESIGN.md` exists at the chosen location (`docs/DESIGN.md` or root) with all
+  canonical sections, and **`AGENTS.md` references it**.
+- Every documented value traces to the real design source (spot-check a few
+  against the stylesheet/config); inferred values flagged.
+- Documented text-color pairings meet **WCAG AA** contrast; token references
+  resolve (no orphans/broken refs).
+- File is Markdown-first and compact (~2–5K tokens); no build dependency added.
+
+### Step 5 — (Optional) install the `/design-system` delegator
+If the developer wants a one-command refresh later, install a `/design-system`
+delegator into the repo's `.agents/commands/` (template:
+`templates/design-system-command.md`) that re-runs this addon. Skip if not wanted —
+a declined command leaves a baseline-conformant repo.
+
+## Failure-mode guardrails
+
+- **Never required, never blocking.** If the developer declines, stop cleanly.
+- **Frontend only.** Skip for backend/CLI/non-UI repos — applying it there is a defect.
+- **Reason about the tokens.** Document the repo's real values; never paste a brand file.
+- **Reconcile, don't clobber.** Preserve a working `DESIGN.md`; ask before destructive edits.
+- **Protect accessibility.** Capture the repo's contrast rules; don't document failing pairings.
+- **Reference, don't hard-bind.** Follow the convention's shape, not its Alpha format details.

--- a/.agents/skills/deepworkplan/addons/design-system/SPEC.md
+++ b/.agents/skills/deepworkplan/addons/design-system/SPEC.md
@@ -1,0 +1,256 @@
+# SPEC.md — Design-System Addon (Normative)
+
+## Abstract
+
+This document is the **normative specification** of the DeepWorkPlan
+**design-system addon**: an opt-in capability that gives a **frontend/UI
+repository** a **`DESIGN.md`** — placed under **`docs/`** alongside the repo's
+other specs and indexed from `AGENTS.md` — a Markdown design-system file that any
+coding agent reads to generate UI **consistent with the repo's own design
+system**. It defines the **frontend-scope gate** (RFC-2119), the **location +
+`AGENTS.md` discovery** rule, the **canonical sections** a `DESIGN.md` MUST carry,
+the **reason-don't-copy** rule, the
+**reconcile-don't-clobber** behavior, the **pragmatic-reference** posture toward
+the upstream convention, the **onboarding hook**, and the **validation** step.
+
+The addon is **stack-aware**: it reasons about the repo's **actual** design tokens
+(CSS custom properties, a Tailwind config, design-token files, component styles)
+rather than copying a third-party brand file. It is governed by `../README.md` and
+`methodology-spec/ADDONS.md`: it is **never** required for baseline AI-first
+conformance — a repo with zero addons is fully conformant.
+
+## Status of This Document
+
+| Field | Value |
+|-------|-------|
+| **Version** | 2.0.0 |
+| **Status** | Stable |
+| **Companions** | `SKILL.md`, `templates/DESIGN.md.md`, `templates/presets.md`, `templates/agent_prompt_guide.md`, `../README.md`, `methodology-spec/ADDONS.md` |
+| **License** | MIT |
+
+## 1. Conventions
+
+The RFC 2119 keywords (**MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**,
+**MAY**, **OPTIONAL**) are interpreted as in
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+Throughout, **`DESIGN.md`** is the design-system file this addon produces (at
+`docs/DESIGN.md` by default, §2); a **token** is a named design value (a color, a
+type size, a spacing
+step, a radius, an elevation); and the **design source** is the repo's real
+origin of those values (a stylesheet, a Tailwind config, a token file, or the
+component styles themselves).
+
+---
+
+## 2. What the Addon Provides
+
+- The addon **MUST** produce a single **`DESIGN.md`** — a Markdown file,
+  human-authorable and LLM-legible, that documents the repo's design system so an
+  agent generating UI follows it instead of inventing statistically-common
+  defaults. It **MUST** be version-controlled and reviewable in pull requests.
+- **Location (DWP-native default):** in a repo that follows the DWP documentation
+  standard — specs/docs centralized under `docs/` and indexed by `AGENTS.md` —
+  `DESIGN.md` **SHOULD** live at **`docs/DESIGN.md`**, alongside the other specs
+  (`ARCHITECTURE.md`, `STANDARDS.md`, `PRODUCT_SPEC.md`, …), **not** scattered at
+  the root. A repo with **no** `docs/` tree (or one mirroring the upstream
+  root convention) **MAY** instead place it at the repo root (`./DESIGN.md`).
+- **Discovery is by reference, not by physical location.** Wherever it lives, the
+  addon **MUST** ensure `AGENTS.md` (and therefore `CLAUDE.md`) **references**
+  `DESIGN.md` in its documentation index, so any agent discovers it the same way it
+  discovers the rest of the `docs/` specs. The location matters less than the
+  `AGENTS.md` pointer being present.
+- The file **SHOULD** stay compact (roughly 2–5K tokens) so it fits comfortably in
+  an agent's context window alongside the task.
+- The addon **MUST NOT** introduce a build dependency, a plugin, or an external
+  source of truth; `DESIGN.md` is plain Markdown readable by any agent.
+
+---
+
+## 3. Frontend-Scope Gate (the part the addon reasons about)
+
+- The addon is **frontend/UI-scoped**. It **MUST** be offered (and applied) only
+  when the repo has a **user-facing UI surface**.
+- The agent **MUST** detect frontend scope from **real files**, e.g.:
+
+  | Signal | Example evidence |
+  |--------|------------------|
+  | Stylesheet / tokens | `*.css`, `*.scss`, CSS custom properties, a `tokens.*` / `theme.*` file |
+  | Utility/theme config | `tailwind.config.*`, a Tailwind v4 `@theme` block in CSS, CSS-in-JS theme |
+  | UI components | `.jsx`/`.tsx`/`.vue`/`.svelte`/`.astro` components, a component library |
+  | Design assets | a brand/style guide doc, a design-tokens export, a Figma reference |
+
+- A repo with **no** UI surface (a pure backend service, a CLI, a library with no
+  rendered output) **MUST** have this addon **skipped**; applying it there is a
+  defect.
+- The addon is **archetype-agnostic** (`ARCHETYPES.md`): it MAY be layered onto an
+  individual repo or onto a UI sub-repo of an orchestrator hub.
+
+### 3.1 Recommendation Strength — Default-On When Detected
+
+This addon is **conditionally default-on**: it is **never** part of the zero-addon
+baseline (a repo with no addons is fully conformant — `ADDONS.md` §2), but when the
+frontend-scope signal above **is** detected, onboarding **SHOULD** actively drive it
+in, not merely list it:
+
+- When a UI surface **is** detected:
+  - In **trust mode**, the `onboard` flow **SHOULD apply** the addon automatically
+    (generate `DESIGN.md`), the same way it applies other detected-and-applicable
+    setup — the developer **MAY** still decline.
+  - In **guided mode**, the flow **MUST** present it as a **strong recommendation**
+    and ask before applying.
+- When a UI surface is **not** detected, the flow **MUST NOT** offer it.
+- Declining **MUST** always remain possible, and a declined addon **MUST** leave a
+  fully baseline-conformant repo. "Default-on when detected" raises the *default*,
+  it does **not** make the addon mandatory.
+
+This places `design-system` in the **strongest conditional tier** among the addons:
+weaker than the stack-agnostic baseline (which it is not part of), but stronger than
+a neutral opt-in — because a repo that *has* a design system almost always benefits
+from capturing it as `DESIGN.md`.
+
+---
+
+## 4. Canonical Sections of `DESIGN.md`
+
+A conformant `DESIGN.md` **MUST** contain the following sections (titles MAY be
+adapted to the repo's voice; the substance MUST be present). Each section is
+**filled by reasoning about the design source**, never copied from a brand file.
+
+1. **Overview / Atmosphere** — brand personality, emotional tone, the design's
+   intent in one short paragraph.
+2. **Color Palette & Roles** — semantic colors (primary, secondary, neutral,
+   surface, accent, state colors) with values **and** their functional role; light
+   and dark variants where the repo supports dark mode.
+3. **Typography** — font families, the type scale (sizes/weights/line-heights), and
+   when each level is used.
+4. **Layout & Spacing** — the spacing scale (base unit + steps), grid/container
+   strategy, and whitespace principles.
+5. **Elevation & Depth** — shadow/surface hierarchy and how depth is expressed.
+6. **Shapes** — border-radius scale and corner language; border/hairline treatment.
+7. **Components** — the repo's key UI patterns (buttons, inputs, cards, nav, …)
+   described in terms of the tokens above, including interaction states.
+8. **Responsive Behavior** — breakpoints and touch-target expectations.
+9. **Do's and Don'ts** — explicit guardrails for agent behavior, including
+   **accessibility constraints** the repo enforces (see §7).
+10. **Agent Prompt Guide** — a short "how to use this file" block telling a
+    downstream agent to follow `DESIGN.md` and how to reference tokens.
+
+- Color/spacing/type values **SHOULD** be expressed as **named tokens** with
+  human-readable usage notes; the file **MAY** additionally carry a
+  machine-readable token block (e.g. front matter) when the repo already maintains
+  structured tokens, but a Markdown-first table is sufficient and preferred for
+  authorability.
+
+---
+
+## 5. Reason, Don't Copy
+
+- Every value in `DESIGN.md` **MUST** be **derived from the repo's real design
+  source** — the stylesheet, Tailwind config, token files, or component styles
+  that actually exist.
+- The addon **MUST NOT** paste a third-party brand's `DESIGN.md` (e.g. a catalog
+  entry for Stripe, Linear, or any other site) into the target repo. Reference
+  catalogs are **inspiration for structure**, never the content.
+- When a value is genuinely undefined in the repo, the addon **SHOULD** infer the
+  most consistent value from existing usage and **MUST** flag it as inferred (so a
+  human can confirm), rather than fabricate an unrelated value.
+
+---
+
+## 6. Reconcile, Don't Clobber
+
+- If a `DESIGN.md` (or an equivalent design-token source) **already exists**, the
+  addon **MUST** reconcile additively — preserving values that already work and
+  bringing the rest toward the canonical-section shape.
+- The addon **MUST NOT** overwrite or delete an existing `DESIGN.md` or token file
+  wholesale. Per `AGENT_PROTOCOL.md`, any destructive change to an existing file
+  **MUST** be approved by the developer first.
+- The addon **MUST** record what it changed (added sections, reconciled values,
+  inferred values flagged for confirmation).
+
+---
+
+## 7. Accessibility & Token Integrity
+
+- The Do's and Don'ts section **MUST** capture the repo's **real accessibility
+  rules** (e.g. WCAG AA contrast targets, approved/forbidden text colors) when the
+  repo documents them, so agents do not regress contrast.
+- Documented color pairings intended for text **SHOULD** meet **WCAG AA** contrast
+  (4.5:1 normal, 3:1 large) and the addon **SHOULD** sanity-check the pairings it
+  documents.
+- Token references inside `DESIGN.md` **MUST** resolve — no orphaned or broken
+  references (a component referencing a token that is not defined).
+
+---
+
+## 8. Pragmatic Reference, Not Hard Binding
+
+- The addon **references** the emerging `DESIGN.md` convention (introduced by
+  Google Stitch; popularized by community catalogs) as the **shape** to follow, but
+  **MUST NOT** hard-bind to that convention's evolving/Alpha format details.
+- DWP's `DESIGN.md` is **Markdown-first**; adopting any specific machine-readable
+  token schema (e.g. W3C Design Tokens front matter) is **OPTIONAL** and applied
+  only when it fits the repo.
+
+---
+
+## 9. Onboarding Hook + Optional `/design-system` Delegator
+
+- The addon's onboarding hook (`SKILL.md`) is offered by `onboard` Phase 7b as an
+  **opt-in** step, **only for frontend repos** (§3), and **MUST NOT** be applied
+  without acceptance. A declined addon leaves a baseline-conformant repo.
+- The addon **MAY** install a `/design-system` delegator command into the target
+  repo's `.agents/commands/` (to regenerate/refresh `DESIGN.md` later; template:
+  `templates/design-system-command.md`). Installing the command is **OPTIONAL**; a
+  declined addon installs **no** command.
+
+---
+
+## 10. Relationship to Per-Feature Design Docs (positioning)
+
+- This addon provides a **repo-level, persistent design-system file**. It is
+  **distinct** from a **per-feature technical design document** (the
+  "requirements → design → tasks" `design.md` of tool-bound spec-driven workflows).
+- DeepWorkPlan deliberately does **not** ship a separate per-feature design-doc
+  archetype: a DWP plan's README (Goal + Context), each task's Context and
+  **Acceptance Criteria**, and the **validation gates** already fulfill the
+  per-feature design role. This addon fills the one gap that role does not cover —
+  durable, repo-native **UI** design context.
+
+---
+
+## 11. Validation Step (run after applying)
+
+The addon is correctly applied when **all** hold:
+
+1. The repo was confirmed to have a **frontend/UI surface** (§3); the addon was
+   **skipped** for non-UI repos.
+2. A `DESIGN.md` exists with all canonical sections (§4) — at **`docs/DESIGN.md`**
+   for a repo with a `docs/` tree (DWP-native default), or at the repo root for a
+   repo without one (§2).
+3. **`AGENTS.md` references `DESIGN.md`** in its documentation index (so agents
+   discover it like the other `docs/` specs) (§2).
+4. Every documented value is **traceable to the repo's real design source** (§5);
+   no third-party brand file was pasted; inferred values are flagged.
+5. An **existing** `DESIGN.md`/token source, if present, was **reconciled** (§6),
+   not clobbered; destructive changes were approved.
+6. Documented text color pairings meet **WCAG AA**; token references **resolve**
+   (no orphans/broken refs) (§7).
+7. The file is Markdown-first and compact; no build dependency was introduced (§2).
+8. If a `/design-system` delegator was offered and accepted, it exists in the
+   repo's `.agents/commands/`; if declined, none was installed (§9).
+
+---
+
+## 12. References
+
+- [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
+- `SKILL.md` (the onboarding hook + flow), `templates/*` (reasoning aids)
+- `../README.md` (addon mechanism), `methodology-spec/ADDONS.md` (concept + pointer)
+- `AGENT_PROTOCOL.md` (approval gates), `ARCHETYPES.md` (archetypes)
+- [W3C Design Tokens](https://www.w3.org/community/design-tokens/) (optional token schema)
+
+---
+
+*Part of the DeepWorkPlan methodology v2.0.0, MIT License, by [Dailybot](https://dailybot.com) / dailybotops.*

--- a/.agents/skills/deepworkplan/addons/design-system/templates/DESIGN.md.md
+++ b/.agents/skills/deepworkplan/addons/design-system/templates/DESIGN.md.md
@@ -1,0 +1,99 @@
+# Reasoning template — `DESIGN.md` skeleton
+
+This is the **annotated skeleton** the addon fills by **reasoning about the target
+repo's real design source** (stylesheet, Tailwind config, token files, component
+styles). The *shape* below is fixed; every *value* is derived from the repo — see
+`SPEC.md` §4–§5. Replace each `> how to fill` note with real content and delete the
+notes. Keep the result compact (~2–5K tokens) and Markdown-first.
+
+> **Do not** paste a third-party brand's `DESIGN.md` here. Reference catalogs are
+> inspiration for structure only.
+
+---
+
+```markdown
+# DESIGN.md — {Project} design system
+
+> Design-system context for AI coding agents. When generating or editing UI in
+> this repo, follow this file. Prefer the named tokens below over ad-hoc values.
+
+## Overview
+> how to fill: one short paragraph — brand personality, tone, the design's intent.
+> Pull from the brand/style guide if one exists; otherwise infer from the UI and flag it.
+
+## Colors
+> how to fill: read the real palette (Tailwind theme colors / CSS `--` vars / token
+> file). List SEMANTIC roles + values + usage. Include dark-mode variants if the repo
+> supports dark mode. Note which pairings are for text (and their contrast).
+
+| Token | Value (light) | Value (dark) | Role / usage |
+|-------|---------------|--------------|--------------|
+| `color.bg` | `#…` | `#…` | Page background |
+| `color.text` | `#…` | `#…` | Primary body text |
+| `color.accent` | `#…` | `#…` | Primary actions / links |
+| `color.muted` | `#…` | `#…` | Secondary text (must meet WCAG AA) |
+| … | | | |
+
+## Typography
+> how to fill: real font families + the type scale (size / weight / line-height) and
+> when each level is used. Source: font config + heading/body styles.
+
+| Level | Family | Size / weight / line-height | Used for |
+|-------|--------|-----------------------------|----------|
+| Display | `…` | `…` | Hero / h1 |
+| Heading | `…` | `…` | h2–h4 |
+| Body | `…` | `…` | Paragraphs |
+| Mono | `…` | `…` | Code |
+
+## Layout & spacing
+> how to fill: base spacing unit + steps, container/grid strategy, whitespace rules.
+
+- Spacing scale: `{base}` → `{steps}`
+- Container / grid: `…`
+- Whitespace principle: `…`
+
+## Elevation & depth
+> how to fill: shadow/surface hierarchy, how depth is expressed (or "flat, hairline
+> rules instead of shadows" if that's the system).
+
+## Shapes
+> how to fill: border-radius scale + corner language; border/hairline treatment.
+
+## Components
+> how to fill: the repo's key UI patterns described IN TERMS OF the tokens above,
+> with interaction states. Cover the components that actually exist.
+
+- **Button (primary):** bg `color.accent`, text `…`, radius `…`, states: hover `…`, focus `…`, disabled `…`
+- **Input:** …
+- **Card / surface:** …
+- **Nav / header:** …
+
+## Responsive behavior
+> how to fill: real breakpoints (from the config) + touch-target expectations.
+
+| Breakpoint | Min width | Notes |
+|------------|-----------|-------|
+| sm | `…` | |
+| md | `…` | |
+| lg | `…` | |
+
+## Do's and Don'ts
+> how to fill: explicit guardrails INCLUDING the repo's accessibility rules
+> (approved/forbidden colors, contrast targets). Pull from AGENTS.md / CLAUDE.md.
+
+- DO use the tokens above; DO keep text contrast at WCAG AA (4.5:1 / 3:1).
+- DON'T introduce new colors/fonts outside this file.
+- DON'T `{repo-specific forbidden patterns}`.
+
+## Agent prompt guide
+> how to fill: see templates/agent_prompt_guide.md — a short "how to use this file"
+> block for downstream agents.
+```
+
+---
+
+## After filling
+
+Run the validation step (`SPEC.md` §11): all sections present; values traceable to
+the repo; inferred values flagged; text pairings meet WCAG AA; token references
+resolve; file compact and Markdown-first.

--- a/.agents/skills/deepworkplan/addons/design-system/templates/agent_prompt_guide.md
+++ b/.agents/skills/deepworkplan/addons/design-system/templates/agent_prompt_guide.md
@@ -1,0 +1,43 @@
+# Reasoning template — the "Agent Prompt Guide" block
+
+Every `DESIGN.md` ends with a short **Agent Prompt Guide**: a "how to use this file"
+block that tells a downstream coding agent to follow the design system. Adapt the
+wording to the repo, keep it to a few lines, and reference the repo's real token
+names.
+
+---
+
+## Drop-in block (adapt the bracketed parts)
+
+```markdown
+## Agent prompt guide
+
+**For coding agents working in this repo:** this `DESIGN.md` is the source of truth
+for UI. Before generating or editing any UI:
+
+1. **Use the named tokens** in this file (colors, type, spacing, radius) — do not
+   introduce ad-hoc values or new colors/fonts outside it.
+2. **Respect roles** — pick a color by its *role* (e.g. `color.accent` for primary
+   actions), not by eyeballing a hex.
+3. **Keep accessibility** — text pairings must meet the contrast targets in Do's &
+   Don'ts; never use a forbidden color for body text.
+4. **Match component patterns** — reuse the documented Button/Input/Card/Nav
+   patterns and their interaction states.
+5. **When something isn't covered**, choose the option most consistent with the
+   tokens here and note the gap rather than inventing an unrelated style.
+
+Suggested instruction to paste into an agent prompt:
+> "Follow `DESIGN.md` strictly. Build [the UI] using its tokens, roles, and
+>  component patterns; keep text contrast at WCAG AA."
+```
+
+---
+
+## Notes
+
+- Reference the repo's **actual** token names (e.g. `color.accent`, `--color-ink`,
+  `oxblood`) so the guidance is concrete, not generic.
+- If the repo installed a `/design-system` delegator, you MAY mention it here
+  ("run `/design-system` to refresh this file after design changes").
+- Keep this block short — its job is to point agents at the rest of the file, not to
+  repeat it.

--- a/.agents/skills/deepworkplan/addons/design-system/templates/design-system-command.md
+++ b/.agents/skills/deepworkplan/addons/design-system/templates/design-system-command.md
@@ -1,0 +1,46 @@
+# Template — `/design-system` delegator command (reasoning aid)
+
+This is the **delegator command** the design-system addon **MAY** install into the
+target repo's `.agents/commands/design-system.md` **only when the addon is
+accepted** during `onboard` Phase 7b (or when the addon is run directly) **and** the
+developer wants a one-command way to refresh `DESIGN.md` later. It is a **thin
+delegator**: it carries no logic of its own — it routes to the
+`deepworkplan-addon-design-system` addon, which holds the real flow.
+
+Installing this command is **optional** (`SPEC.md` §9). Fill the placeholders by
+reasoning about the target repo (its real design source and accessibility rules);
+do not copy verbatim. Decline the addon → do **not** install this command.
+
+```markdown
+---
+name: design-system
+description: Create or refresh this repo's DESIGN.md (design tokens + rules for AI agents; at docs/DESIGN.md, indexed from AGENTS.md) via the DeepWorkPlan design-system addon.
+---
+
+# /design-system
+
+Create or refresh this repository's `DESIGN.md` (at `docs/DESIGN.md`, indexed from
+`AGENTS.md`) so coding agents generate
+UI consistent with this repo's **own** design system. This command is a **thin
+delegator** to the DeepWorkPlan `deepworkplan-addon-design-system` addon — it does
+not contain the logic itself.
+
+## Steps
+
+1. Invoke the `deepworkplan-addon-design-system` addon (via
+   `/deepworkplan-addon-design-system` or by reading the addon's `SKILL.md`).
+2. Follow the addon's flow: locate this repo's real design source
+   (<e.g. CSS custom properties in `src/styles/global.css` + a Tailwind `@theme`
+   block>), reason out each canonical section of `DESIGN.md` from those tokens,
+   and write or **reconcile** `DESIGN.md` at its location (`docs/DESIGN.md` for a
+   repo with a `docs/` tree; root otherwise), ensuring `AGENTS.md` references it.
+3. Run the addon's validation step (sections present, values traceable to the real
+   source, WCAG AA contrast, token references resolve).
+
+## Notes
+
+- Design source for this repo: <fill in — e.g. Tailwind config / CSS vars / token file>.
+- Accessibility rules to enforce: <fill in — e.g. WCAG AA, approved/forbidden text colors>.
+- Reason about the real tokens — never paste a third-party brand's `DESIGN.md`.
+- Reconcile an existing `DESIGN.md`; ask before any destructive change.
+```

--- a/.agents/skills/deepworkplan/addons/design-system/templates/presets.md
+++ b/.agents/skills/deepworkplan/addons/design-system/templates/presets.md
@@ -1,0 +1,55 @@
+# Reasoning presets — where a repo's design tokens live
+
+Match the row(s) for the **detected stack** as a *starting checklist* for **where to
+read** the repo's real design values, then verify every assumption against the
+actual files. **Detected reality wins** — a repo may combine several sources.
+
+> These presets tell you **where to look**, not **what to write**. The values you
+> document come from the repo (`SPEC.md` §5), never from this file or a brand catalog.
+
+---
+
+## Tailwind (v3 config or v4 `@theme`)
+
+- **Tokens:** `tailwind.config.{js,ts,cjs,mjs}` → `theme` / `theme.extend`
+  (`colors`, `fontFamily`, `fontSize`, `spacing`, `borderRadius`, `boxShadow`,
+  `screens`). For **Tailwind v4**, read the `@theme { --color-…; --font-…; --spacing-…; }`
+  block inside the global CSS instead of a JS config.
+- **Dark mode:** `darkMode` strategy + `dark:` variants in components.
+- **Breakpoints:** `theme.screens` (or `@theme` `--breakpoint-*`).
+- **Components:** utility classes in the components reveal real button/input/card patterns.
+
+## CSS variables / vanilla / SCSS
+
+- **Tokens:** `:root { --… }` (and a `.dark`/`[data-theme]` block) in the global
+  stylesheet — colors, spacing, radius, shadows, font stacks.
+- **Type scale:** heading/body rules; `clamp()` for fluid type.
+- **Breakpoints:** `@media (min-width: …)` query values.
+- **SCSS:** `$variables` / `@use` token partials (`_tokens.scss`, `_variables.scss`).
+
+## Component library / design tokens
+
+- **Tokens:** a `tokens.{json,ts,js}` / `theme.{ts,js}` export, a Style
+  Dictionary / W3C design-tokens file, or a theme provider (`createTheme`, MUI
+  theme, Chakra theme, styled-components `ThemeProvider`).
+- **Components:** the library's component source + stories (Storybook) show variants
+  and states; map these to the Components section.
+- **Reference syntax:** if the repo already uses `{path.to.token}`-style refs, mirror
+  that in `DESIGN.md`; otherwise plain named tokens are fine.
+
+## Brand / style guide + accessibility rules
+
+- **Brand doc:** any `BRAND*.md`, `STYLE*.md`, or design doc — use for the Overview
+  / atmosphere and intent.
+- **Accessibility:** contrast targets and approved/forbidden colors are often in
+  `AGENTS.md` / `CLAUDE.md` / an accessibility doc — these feed the Do's & Don'ts.
+
+---
+
+## Cross-check before writing
+
+1. Did you read the **actual** token source (not a guess)?
+2. Are **dark-mode** values captured if the repo supports dark mode?
+3. Do the **breakpoints** match the real config?
+4. Are the **accessibility** rules reflected in Do's & Don'ts?
+5. Are any **inferred** values flagged for human confirmation?

--- a/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
+++ b/.agents/skills/deepworkplan/addons/devcontainer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-addon-devcontainer
 description: Optional DeepWorkPlan addon that adds (or reconciles) a compose-based devcontainer to a repo — base image and supporting services reasoned from the detected stack, with persistent AI-CLI auth, the dailybot-project-network, the DOCKER_DEV_ENV=vscode convention, and project-identity precedence. Opt-in, never required, reconciles existing setups instead of clobbering them. Use when the developer wants a reproducible isolated dev container for an AI-first repo.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/author/SKILL.md
+++ b/.agents/skills/deepworkplan/author/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-author
 description: Author or update reusable skills, agents, and commands in the current repo — reason about the repo's .agents/ layout, follow the Open Agent Skills frontmatter contract, and keep the .agents/docs/ catalog in sync. Use when a developer wants to create or evolve the repo's agent kit (skills, agents, commands), or runs /skill-create or /agent-create.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/create/SKILL.md
+++ b/.agents/skills/deepworkplan/create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-create
 description: Create a Deep Work Plan. Gather context, draft, and refine into a single final plan under .dwp/plans/, with a refined draft staged in .dwp/drafts/. Use when the developer wants a new structured multi-task plan.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/execute/SKILL.md
+++ b/.agents/skills/deepworkplan/execute/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-execute
 description: Execute an existing Deep Work Plan task-by-task, run each task's validation, and log progress. Use when the developer wants to run or continue executing a plan in .dwp/plans/.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/onboard/SKILL.md
+++ b/.agents/skills/deepworkplan/onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-onboard
 description: Make a repository AI-first by reasoning about its stack and archetype, then generating adapted AGENTS.md, docs/, per-module docs, .agents/, and the .claude to .agents symlink. Offers opt-in addons. Use when the developer wants to onboard or AI-enable a repo.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write
@@ -370,13 +370,14 @@ After the core AI-first scaffolding, **enumerate** the available addons under
 required** — a repo is fully conformant with zero addons. In **trust mode**, you
 MAY recommend the obviously-applicable ones, but still surface them.
 
-Three addons ship today; enumerate **all** and offer each independently:
+Four addons ship today; enumerate **all** and offer each independently:
 
 | Addon | Folder | Recommend in trust mode when… |
 |-------|--------|-------------------------------|
 | **Devcontainer support** | [`../addons/devcontainer/`](../addons/devcontainer/SKILL.md) | the repo benefits from a reproducible isolated dev container (most repos with Docker/services). |
 | **Dailybot integration** | [`../addons/dailybot/`](../addons/dailybot/SKILL.md) | the developer/team **already uses Dailybot** or asks for team progress reporting — **do NOT auto-install for everyone**. |
 | **Dependency upgrade** | [`../addons/dependency-upgrade/`](../addons/dependency-upgrade/SKILL.md) | the repo has a lockfile + a dependency-heavy stack and wants safe, batched, validated upgrades — recommend only when a lockfile is present; **never auto-install for everyone**. |
+| **Design system** | [`../addons/design-system/`](../addons/design-system/SKILL.md) | **default-on when detected** — whenever the repo has a **UI surface / design system** (a stylesheet with CSS custom properties, a Tailwind config or `@theme` block, UI components, or a brand/style guide), in trust mode **apply** it (generate `DESIGN.md`); in guided mode **strongly recommend** and ask. **Never offer for a backend/CLI/library-only repo.** |
 
 The first addon is **devcontainer support**
 ([`../addons/devcontainer/SKILL.md`](../addons/devcontainer/SKILL.md) +
@@ -430,6 +431,33 @@ batch, revert a failing batch, and summarize. **Only when accepted**, the addon
 installs a `/lib-upgrade` delegator into the repo's `.agents/commands/`. After
 applying, run the addon's validation step (SPEC §9). If declined, skip it — the
 repo stays baseline-conformant and no command is installed.
+
+The fourth addon is **design system**
+([`../addons/design-system/SKILL.md`](../addons/design-system/SKILL.md) +
+[`SPEC.md`](../addons/design-system/SPEC.md)). It is **frontend-scoped** and
+**default-on when detected** (addon SPEC §3.1) — during Phase 1 detection, check
+whether the repo has a **UI surface / design system**: a stylesheet with CSS custom
+properties, a Tailwind config or a Tailwind v4 `@theme {}` block, UI components
+(`.tsx`/`.vue`/`.svelte`/`.astro`), a design-token file, or a brand/style guide.
+When that signal **is** present, do not merely list the addon: in **trust mode
+apply it automatically** (generate `DESIGN.md`, developer may still decline), and in
+**guided mode present it as a strong recommendation** and ask. When the signal is
+**absent**, **do not offer it** (a backend/CLI/library-only repo must never get a
+`DESIGN.md`). Declining always leaves a baseline-conformant repo. If accepted (or
+auto-applied): read that addon's `SKILL.md` and run
+its flow — locate the repo's **real** design source, **reason out** each canonical
+section of `DESIGN.md` from those tokens (Overview/atmosphere, colors & roles incl.
+dark mode, typography, layout & spacing, elevation, shapes, components, responsive
+behavior, do's & don'ts incl. the repo's accessibility rules, agent prompt guide),
+and write it at **`docs/DESIGN.md`** (alongside the other specs you generated in
+Phase 4 — root only if the repo has no `docs/` tree) — **never** copying a
+third-party brand file. Then **add a `DESIGN.md` reference to the `AGENTS.md`
+documentation index** (and `CLAUDE.md`) so agents discover it like the rest of
+`docs/`. An **existing `DESIGN.md`/token source MUST be reconciled, not clobbered**.
+After applying, run the addon's validation step (SPEC §11: file at `docs/DESIGN.md`
+or root with all sections, AGENTS.md references it, values traceable to the real
+source, WCAG AA contrast, token references resolve). If declined, skip it — the repo
+stays baseline-conformant.
 
 ## Phase 8 — Self-check / validation (mandatory)
 

--- a/.agents/skills/deepworkplan/refine/SKILL.md
+++ b/.agents/skills/deepworkplan/refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-refine
 description: Refine a Deep Work Plan draft or modify an existing final plan. Use when the developer wants to adjust scope, tasks, or details of a draft in .dwp/drafts/ or a plan in .dwp/plans/.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/resume/SKILL.md
+++ b/.agents/skills/deepworkplan/resume/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-resume
 description: Resume an interrupted Deep Work Plan from its recorded progress state. Use when the developer wants to continue a plan in .dwp/plans/ that was paused or interrupted mid-execution.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/spec/ADDONS.md
+++ b/.agents/skills/deepworkplan/spec/ADDONS.md
@@ -97,7 +97,7 @@ An addon **MAY** additionally ship examples, per-stack presets, or migration not
 
 ## 6. Shipping Addons
 
-Two addons ship today. Both are **opt-in** and **never required** — a repository
+Four addons ship today. All are **opt-in** and **never required** — a repository
 is fully conformant with **zero** addons installed.
 
 ### 6.1 Devcontainer Support (first addon)
@@ -156,6 +156,70 @@ is fully conformant with **zero** addons installed.
   never-block rule, vendor-neutral guardrail, validation), and
   `templates/INTEGRATION.md` (reasoning aid).
 
+### 6.3 Dependency Upgrade (third addon)
+
+- **Dependency upgrade** is the **third** addon. Its full normative content (spec,
+  reasoning templates, onboarding hook, validation step, the `/lib-upgrade`
+  delegator template) **MUST** live at:
+
+  ```
+  skills/deepworkplan/addons/dependency-upgrade/
+  ```
+
+- Scope: **package-manager agnostic**, **opt-in** dependency upgrades. When
+  accepted, it detects the repo's **real** package manager (npm/pnpm/yarn + ncu,
+  pip/poetry/uv, cargo, go mod, bundler, composer, …), classifies upgrades by
+  semver, upgrades in **safe batches**, runs the repo's **real** validation gate
+  after each batch, **reverts** a failing batch, and summarizes — and **only when
+  accepted** installs a `/lib-upgrade` delegator into the repo's
+  `.agents/commands/`.
+- The full implementation lives at
+  `skills/deepworkplan/addons/dependency-upgrade/` — see its
+  [`SKILL.md`](../addons/dependency-upgrade/SKILL.md) (onboarding hook),
+  [`SPEC.md`](../addons/dependency-upgrade/SPEC.md) (RFC-2119 contract: detection,
+  semver classification, batched upgrade, validate-after-each-batch gate,
+  revert-on-failure, reconcile-don't-clobber, validation), and `templates/`.
+
+### 6.4 Design System (fourth addon)
+
+- **Design system** is the **fourth** addon. Its full normative content (spec,
+  reasoning templates, onboarding hook, validation step) **MUST** live at:
+
+  ```
+  skills/deepworkplan/addons/design-system/
+  ```
+
+- Scope: a **frontend/UI-scoped**, **opt-in** capability that gives a repo a
+  **`DESIGN.md`** — placed at **`docs/DESIGN.md`** alongside the repo's other specs
+  (root only if the repo has no `docs/` tree) and **indexed from `AGENTS.md`** — a
+  Markdown design-system file any coding agent reads to generate UI consistent with
+  the repo's **own** design system. When accepted,
+  it **reasons about the repo's actual design tokens** (CSS custom properties, a
+  Tailwind config, token files, component styles) — **never** copying a brand file —
+  documents the canonical sections (colors & roles, typography, layout/spacing,
+  elevation, shapes, components, responsive behavior, do's & don'ts, agent prompt
+  guide), checks **WCAG AA** contrast and token integrity, and reconciles an
+  existing `DESIGN.md` instead of clobbering it. It is **default-on when detected**
+  (addon SPEC §3.1): when a UI surface / design system **is** detected the `onboard`
+  flow **applies** it in trust mode and **strongly recommends** it in guided mode;
+  when no UI surface is present it is **not** offered. It remains **never required** —
+  a zero-addon repo is fully conformant.
+- **Distinct from per-feature design docs:** this addon provides a **repo-level,
+  persistent** design-system file; it is **not** a per-feature technical design
+  document (the "requirements → design → tasks" `design.md` of tool-bound
+  spec-driven workflows). DeepWorkPlan deliberately ships **no** separate
+  per-feature design-doc archetype — a plan's README (Goal + Context), each task's
+  Context and **Acceptance Criteria**, and the **validation gates** already fulfill
+  that role; this addon fills the one gap that role does not cover: durable,
+  repo-native **UI** design context.
+- The full implementation lives at
+  `skills/deepworkplan/addons/design-system/` — see its
+  [`SKILL.md`](../addons/design-system/SKILL.md) (onboarding hook),
+  [`SPEC.md`](../addons/design-system/SPEC.md) (RFC-2119 contract: frontend-scope
+  gate, canonical sections, reason-don't-copy, reconcile-don't-clobber,
+  accessibility & token integrity, pragmatic-reference posture, validation), and
+  `templates/` (the `DESIGN.md` skeleton, per-stack presets, agent prompt guide).
+
 > This `ADDONS.md` is the concept + pointer; it **MUST NOT** be treated as any
 > addon's implementation.
 
@@ -168,6 +232,8 @@ is fully conformant with **zero** addons installed.
 - `../RECONCILIATION.md` (divergence #7), `../../ORCHESTRATOR_MANIFEST.md` (devcontainer-addon decision)
 - Devcontainer addon implementation (`skills/deepworkplan/addons/devcontainer/`)
 - Dailybot addon implementation (`skills/deepworkplan/addons/dailybot/`)
+- Dependency-upgrade addon implementation (`skills/deepworkplan/addons/dependency-upgrade/`)
+- Design-system addon implementation (`skills/deepworkplan/addons/design-system/`)
 
 ---
 

--- a/.agents/skills/deepworkplan/status/SKILL.md
+++ b/.agents/skills/deepworkplan/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-status
 description: Report the status of a Deep Work Plan — completed tasks, what's left, and blockers — without executing. Use when the developer asks for plan status or what remains.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob, Edit, Write

--- a/.agents/skills/deepworkplan/verify/SKILL.md
+++ b/.agents/skills/deepworkplan/verify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deepworkplan-verify
 description: Verify that a repository is DeepWorkPlan-conformant (AI-first) and that its plans are well-formed, producing an objective pass/fail report. Use when the developer asks to verify, audit, or check conformance of a repo or a plan.
-version: "2.5.0"
+version: "2.7.0"
 documentation_url: https://deepworkplan.com
 user-invocable: true
 allowed-tools: Bash, Read, Grep, Glob

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "DailybotHQ/deepworkplan-skill",
       "sourceType": "github",
       "skillPath": "skills/deepworkplan/SKILL.md",
-      "computedHash": "7f00ff227f7ca11ca3432001b013e667c9265454789dc395e54900e5e2442f24"
+      "computedHash": "3568162def9cde39fac4693beb8bf652200af3fb3425715ec63d53081023bf61"
     }
   }
 }


### PR DESCRIPTION
## What

Update the installed `deepworkplan` skill **v2.5.0 → v2.7.0** (`skills-lock.json` re-pinned, hash `7f00ff…` → `3568162…`).

## Trust & verification (new in init.md)

Followed the new "Trust and verification" step before installing:
- **Provenance** confirmed via `deepworkplan.com/.well-known/dwp-trust.json` and the `DailybotHQ/deepworkplan-skill` GitHub release (MIT, markdown-first, no network/telemetry).
- **Integrity** verified against the **v2.7.0 `SHA256SUMS`** with `setup.sh --verify` → **"Integrity OK"** — only then installed.

## What changed in 2.5.0 → 2.7.0

- Skill text edits across sub-skills + a **4th opt-in addon: `design-system`** (`addons/design-system/`, 6 new files).
- **Conformance contract unchanged:** `verify` criteria, the `docs/` MUST floor, and the `dwp-*` command-templates are all identical → **no repo artifacts needed changes** (`PRODUCT_SPEC.md` from v2.5.0 still satisfies the floor).

## Why no `docs/DESIGN.md`

`design-system` is "default-on **when detected**" but explicitly **not for backend/CLI/library-only repos**. This package is a TypeScript **library** with no UI surface (no stylesheet/Tailwind/components/brand guide — the README's `img.emoji` CSS is a consumer hook, not a design system), so `DESIGN.md` correctly does **not** apply.

## Verification

- `prettier:check` clean (vendored pack excluded via existing `.prettierignore`)
- Objective `/dwp-verify` criteria all pass → **CONFORMANT**

🤖 Generated with [Claude Code](https://claude.com/claude-code)